### PR TITLE
Fix Button sizing in Chromatic

### DIFF
--- a/src/stories/Button.js
+++ b/src/stories/Button.js
@@ -14,6 +14,10 @@ export class Button extends LitElement {
 
   static get styles() {
     return css`
+    :host {
+      display: inline-block;
+    }
+    
     .storybook-button {
       font-family: 'Nunito Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
       font-weight: 700;


### PR DESCRIPTION
This PR fixes the Button component so that it renders correctly in Storybook / Chromatic. Should be merged before #63, as the change is also present in that branch due to unsuccessful tests.

The consequences of this change can be seen on [Build 35](https://www.chromatic.com/build?appId=640a4d93e34604f275368983&number=35).