### PR TITLE
Drag and drop files

### DIFF
--- a/src/stories/FileSystemSelector.js
+++ b/src/stories/FileSystemSelector.js
@@ -1,0 +1,129 @@
+import { LitElement, css, html } from 'lit';
+
+import { remote } from '../electron/index'
+const { dialog } = remote
+
+const componentCSS = css`
+
+    * {
+      box-sizing: border-box;
+    }
+
+    :host {
+      display: inline-block;
+    }
+
+    button { 
+      background: WhiteSmoke;
+      border: 1px solid #c3c3c3;
+      border-radius: 4px;
+      padding: 25px;
+      width: 100%;
+      color: dimgray;
+      cursor: pointer;
+      overflow-wrap: break-word;
+      text-align: center;
+      transition: background 0.5s;
+    }
+
+    small {
+      color: silver;
+    }
+    
+    :host(.active) button {
+      background: Gainsboro;
+    }
+
+`
+
+document.addEventListener('dragover', (e) => {
+  e.preventDefault();
+  e.stopPropagation();
+});
+
+export class FilesystemSelector extends LitElement {
+
+
+  static get styles() {
+    return componentCSS
+  }
+
+  static get properties() {
+    return {
+      value: { type: String, reflect: true }
+    };
+  }
+
+  constructor (props = {}) {
+    super()
+    if (props.onChange) this.onChange = props.onChange
+    this.type = props.type ?? 'file'
+    this.value = props.value ?? ''
+    this.dialogOptions = props.dialogOptions ?? {}
+    this.dialogType = props.dialogType ?? 'showOpenDialog'
+  }
+
+  onSelect = () => {}
+
+  display = document.createElement('small')
+
+  #useElectronDialog = async (type) => {
+
+    const options = { ...this.dialogOptions }
+    options.properties = [type === 'file' ? 'openFile' : 'openDirectory', 'noResolveAliases', ...options.properties ?? []]
+    this.classList.add('active')
+    const result = await dialog[this.dialogType](options);
+    this.classList.remove('active')
+    if (result.canceled) throw new Error('No file selected')
+    return result
+  }
+
+  #handleFile = async (path) => {
+    if (!path) throw new Error('Unable to parse file path')
+    this.value = path
+    this.onSelect(path)
+  }
+
+
+  render() {
+
+    return html`
+    <button @click=${async () => {
+      if (dialog) {
+        const file = await this.#useElectronDialog(this.type)
+        const path = file.filePath ?? file.filePaths?.[0]
+        this.#handleFile(path)
+      } else {
+        let handles = (this.type === 'directory') ? await window.showDirectoryPicker() :  await window.showOpenFilePicker();
+        this.#handleFile((handles[0] ?? handles).name)
+      }
+      }}
+
+      @dragenter=${() => {
+        this.classList.add('active')
+      }}
+
+      @dragleave=${() => {
+        this.classList.remove('active')
+      }}
+      
+      @drop=${async (event) => {
+        event.preventDefault();
+        event.stopPropagation();
+        this.classList.remove('active')
+
+        let pathArr = [];
+        for (const f of event.dataTransfer.files) pathArr.push(f.path)
+        if (pathArr.length > 1) console.error('Only one file can be registered at a time')
+        this.#handleFile(pathArr[0])
+      }}
+      
+      
+      >${this.value || `Drop a ${this.type} here, or click to choose a ${this.type}`}
+      ${dialog ? '' : html`<br><small>Cannot get full ${this.type} path on web distribution</small>`}
+      </button>
+    `
+  }
+};
+
+customElements.get('nwb-filesystem-selector') || customElements.define('nwb-filesystem-selector',  FilesystemSelector);

--- a/src/stories/FileSystemSelector.stories.js
+++ b/src/stories/FileSystemSelector.stories.js
@@ -1,0 +1,13 @@
+import { FilesystemSelector } from './FileSystemSelector';
+
+export default {
+  title: 'Components/Filesystem Selector'
+};
+
+const Template = (args) => new FilesystemSelector(args);
+
+export const File = Template.bind({});
+export const Folder = Template.bind({});
+Folder.args = {
+  type: 'directory'
+}


### PR DESCRIPTION
fix #76

This PR allows for users to drag and drop files in addition to the previous dialog-based workflow. The new "Filesystem Selector" component is reviewable on Storybook / Chromatic. 

![Screenshot 2023-03-29 at 11 16 20 AM](https://user-images.githubusercontent.com/46533749/228630956-d9af2801-48ae-46c4-979d-7f07ca0f803d.png)

While the interactions with this component are identical across Electron / Storybook, the component is rendered slightly differently when in the Electron app to indicate that there is no issue discovering full paths in this context.

![Screenshot 2023-03-29 at 11 15 15 AM](https://user-images.githubusercontent.com/46533749/228630692-ab16aeaf-efe6-4e6a-9d30-ebf180557d15.png)

Based on discussions with Cody, we based our component on the following image:
![image](https://user-images.githubusercontent.com/46533749/228630342-291b8ad4-233d-423f-98cd-a952fedacdc5.png)
