### PR TITLE
Fix frontend resolution for Electron build

### DIFF
--- a/index.html
+++ b/index.html
@@ -26,10 +26,10 @@
       if (isElectron) {
         const stylesheet = document.createElement("link") // Import bundled CSS for Electron
         stylesheet.rel = "stylesheet"
-        stylesheet.href = "./dist/style.css"
+        stylesheet.href = "./src/dist/style.css"
         document.head.insertAdjacentElement('afterbegin', stylesheet) // ensure css is least priority
 
-        const dist = "./dist/index.js"
+        const dist = "./src/dist/index.js"
         await import(dist /* @vite-ignore */) // Load packaged frontend for Electron
       }
 

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,6 +2,7 @@ import { defineConfig } from "vite";
 
 export default defineConfig({
   build: {
+    outDir: 'src/dist',
     lib: {
       entry: {
         index: 'src/index.js',


### PR DESCRIPTION
fix #90

replace #91

This PR moves the `dist` folder to `src/dist` to ensure proper resolution of the frontend on Electron builds.