### PR TITLE
Maintain active project on page reload

### DIFF
--- a/src/globals.js
+++ b/src/globals.js
@@ -5,7 +5,13 @@ import checkChromatic from 'chromatic/isChromatic';
 
 import lottie from 'lottie-web'
 
-export const joinPath = (...args) => path?.join(...args);
+export const joinPath = (...args) => path ? path.join(...args) : args.filter(str => str).join('/');
+
+
+export let runOnLoad = (fn) => {
+  if (document.readyState === 'complete') fn();
+  else window.addEventListener('load', fn);
+}
 
 // Base Request URL for Python Server
 export const baseUrl = `http://127.0.0.1:${port}`
@@ -14,8 +20,8 @@ export const baseUrl = `http://127.0.0.1:${port}`
 
 // Filesystem Management
 export const homeDirectory = app?.getPath("home") ?? '';
-export const progressFilePath = joinPath(homeDirectory, "NWB GUIDE", "Progress");
-export const guidedProgressFilePath = joinPath(homeDirectory, "NWB GUIDE", "Guided-Progress");
+export const progressFilePath = homeDirectory ? joinPath(homeDirectory, "NWB GUIDE", "Progress") : '';
+export const guidedProgressFilePath = homeDirectory ? joinPath(homeDirectory, "NWB GUIDE", "Guided-Progress") : '';
 
 export const isStorybook = window.location.href.includes('iframe.html')
 

--- a/src/progress.js
+++ b/src/progress.js
@@ -10,128 +10,149 @@ let saveErrorThrown = false;
 
 
 export const hasEntry = (name) => {
-    const existingProgressNames = getEntries();
-    existingProgressNames.forEach((element, index) => existingProgressNames[index] = element.replace(".json", ""));
-    return existingProgressNames.includes(name);
+  const existingProgressNames = getEntries();
+  existingProgressNames.forEach((element, index) => existingProgressNames[index] = element.replace(".json", ""));
+  return existingProgressNames.includes(name);
 }
 
 export const update = (newDatasetName, previousDatasetName) => {
-    return new Promise((resolve, reject) => {
-        //If updataing the dataset, update the old banner image path with a new one
-        if (previousDatasetName) {
-            if (previousDatasetName === newDatasetName)resolve("No changes made to dataset name");
+  return new Promise((resolve, reject) => {
+    //If updataing the dataset, update the old banner image path with a new one
+    if (previousDatasetName) {
+      if (previousDatasetName === newDatasetName) resolve("No changes made to dataset name");
 
-            if (!fs) console.warn("fs is not defined. Will not perform changes on the filesystem.")
+      if (!fs) console.warn("fs is not defined. Will not perform changes on the filesystem.")
 
-            if (hasEntry(newDatasetName))  reject("An existing progress file already exists with that name. Please choose a different name.");
+      if (hasEntry(newDatasetName)) reject("An existing progress file already exists with that name. Please choose a different name.");
 
-            // update old progress file with new dataset name
-            const oldProgressFilePath = `${guidedProgressFilePath}/${previousDatasetName}.json`;
-            const newProgressFilePath = `${guidedProgressFilePath}/${newDatasetName}.json`;
-            fs?.renameSync(oldProgressFilePath, newProgressFilePath);
-            resolve("Dataset name updated");
-        }
+      // update old progress file with new dataset name
+      const oldProgressFilePath = `${guidedProgressFilePath}/${previousDatasetName}.json`;
+      const newProgressFilePath = `${guidedProgressFilePath}/${newDatasetName}.json`;
+      fs?.renameSync(oldProgressFilePath, newProgressFilePath);
+      resolve("Dataset name updated");
+    }
 
-        else reject('No previous dataset name provided');
-    });
+    else reject('No previous dataset name provided');
+  });
 }
 
 export const save = (page) => {
 
   const globalState = page.info.globalState
-  const guidedProgressFileName = globalState.project.name
+  let guidedProgressFileName = globalState.project?.name
 
-    if (!fs) {
-      if (!saveErrorThrown) console.warn("Cannot save progress in a web build.");
-      saveErrorThrown = true;
+  if (!guidedProgressFileName) {
+    const params = new URLSearchParams(location.search);
+    const projectName = params.get('projectName')
+    if (!projectName) {
+      Swal.fire({
+        title: 'No project loaded. Restart the application and load a valid project.',
+        icon: 'error',
+        confirmButtonText: 'Restart'
+      }).then(() => window.location.href = '/')
       return
     }
-
-    //return if guidedProgressFileName is not a strnig greater than 0
-    if (typeof guidedProgressFileName !== "string" || guidedProgressFileName.length === 0) {
-      console.warn("Failed to save because guidedProgressFileName is not a string or is empty.");
-      return
-    }
-
-    //Destination: HOMEDIR/NWBGUIDE/Guided-Progress
-    globalState["last-modified"] = new Date();
-    globalState["page-before-exit"] = page.info.id;
-
-    try {
-      //create Guided-Progress folder if one does not exist
-      fs.mkdirSync(guidedProgressFilePath, { recursive: true });
-    } catch (error) {
-      console.error(error);
-    }
-
-    var guidedFilePath = joinPath(guidedProgressFilePath, guidedProgressFileName + ".json");
-
-    fs?.writeFileSync(guidedFilePath, JSON.stringify(globalState, null, 2));
-  };
-
-  const readFileAsync = async (path) => {
-    return new Promise((resolve, reject) => {
-      if (!fs) reject('fs is not defined. Please check if fs is defined in the main process.')
-      fs.readFile(path, "utf-8", (error, result) => {
-        if (error) {
-          throw new Error(error);
-        } else {
-          resolve(JSON.parse(result));
-        }
-      });
-    });
-  };
-
-
-  export const getEntries = () => {
-    if (fs && !fs.existsSync(guidedProgressFilePath))  fs.mkdirSync(guidedProgressFilePath, { recursive: true });  //Check if Guided-Progress folder exists. If not, create it.
-    const progressFiles = fs ? fs.readdirSync(guidedProgressFilePath) : [];
-    return progressFiles.filter(path => path.slice(-5) === '.json')
   }
 
-  export const getAll = async (progressFiles) => {
-    return Promise.all(
-      progressFiles.map((progressFile) => {
-        let progressFilePath = joinPath(guidedProgressFilePath, progressFile);
-        return readFileAsync(progressFilePath);
-      })
-    );
-  };
+  const params = new URLSearchParams(location.search);
+  params.set('projectName', guidedProgressFileName);
 
-  export const get = async (progressFile) => {
-    let progressFilePath = joinPath(guidedProgressFilePath, progressFile + ".json");
-    return readFileAsync(progressFilePath);
-  };
+  const value = `${location.pathname}?${params}`
+  history.state.projectName = guidedProgressFileName
 
-  export const deleteProgressCard = async (progressCardDeleteButton) => {
-    const progressCard = progressCardDeleteButton.parentElement.parentElement;
-    const progressCardNameToDelete = progressCard.querySelector(".progress-file-name").textContent;
+  window.history.pushState(history.state, null, value);
 
-    const result = await Swal.fire({
-      title: `Are you sure you would like to delete NWB GUIDE progress made on the dataset: ${progressCardNameToDelete}?`,
-      text: "Your progress file will be deleted permanently, and all existing progress will be lost.",
-      icon: "warning",
-      heightAuto: false,
-      showCancelButton: true,
-      confirmButtonColor: "#3085d6",
-      cancelButtonColor: "#d33",
-      confirmButtonText: "Delete progress file",
-      cancelButtonText: "Cancel",
-      focusCancel: true,
+  if (!fs) {
+    if (!saveErrorThrown) console.warn("Cannot save progress in a web build.");
+    saveErrorThrown = true;
+    return
+  }
+
+  //return if guidedProgressFileName is not a strnig greater than 0
+  if (typeof guidedProgressFileName !== "string" || guidedProgressFileName.length === 0) {
+    console.warn("Failed to save because guidedProgressFileName is not a string or is empty.");
+    return
+  }
+
+  //Destination: HOMEDIR/NWBGUIDE/Guided-Progress
+  globalState["last-modified"] = new Date();
+  globalState["page-before-exit"] = page.info.id;
+
+  try {
+    //create Guided-Progress folder if one does not exist
+    fs.mkdirSync(guidedProgressFilePath, { recursive: true });
+  } catch (error) {
+    console.error(error);
+  }
+
+  var guidedFilePath = joinPath(guidedProgressFilePath, guidedProgressFileName + ".json");
+
+  fs?.writeFileSync(guidedFilePath, JSON.stringify(globalState, null, 2));
+};
+
+const readFileAsync = async (path) => {
+  return new Promise((resolve, reject) => {
+    if (!fs) reject('fs is not defined. Please check if fs is defined in the main process.')
+    fs.readFile(path, "utf-8", (error, result) => {
+      if (error) {
+        throw new Error(error);
+      } else {
+        resolve(JSON.parse(result));
+      }
     });
-    if (result.isConfirmed) {
-      //Get the path of the progress file to delete
-      const progressFilePathToDelete = joinPath(
-        guidedProgressFilePath,
-        progressCardNameToDelete + ".json"
-      );
+  });
+};
 
 
-      //delete the progress file
-      if (fs) fs.unlinkSync(progressFilePathToDelete, (err) => console.log(err));
-      else console.warn(`Cannot delete the progress file`)
+export const getEntries = () => {
+  if (fs && !fs.existsSync(guidedProgressFilePath)) fs.mkdirSync(guidedProgressFilePath, { recursive: true });  //Check if Guided-Progress folder exists. If not, create it.
+  const progressFiles = fs ? fs.readdirSync(guidedProgressFilePath) : [];
+  return progressFiles.filter(path => path.slice(-5) === '.json')
+}
 
-      //remove the progress card from the DOM
-      progressCard.remove();
-    }
-  };
+export const getAll = async (progressFiles) => {
+  return Promise.all(
+    progressFiles.map((progressFile) => {
+      let progressFilePath = joinPath(guidedProgressFilePath, progressFile);
+      return readFileAsync(progressFilePath);
+    })
+  );
+};
+
+export const get = async (progressFile) => {
+  let progressFilePath = joinPath(guidedProgressFilePath, progressFile + ".json");
+  return readFileAsync(progressFilePath);
+};
+
+export const deleteProgressCard = async (progressCardDeleteButton) => {
+  const progressCard = progressCardDeleteButton.parentElement.parentElement;
+  const progressCardNameToDelete = progressCard.querySelector(".progress-file-name").textContent;
+
+  const result = await Swal.fire({
+    title: `Are you sure you would like to delete NWB GUIDE progress made on the dataset: ${progressCardNameToDelete}?`,
+    text: "Your progress file will be deleted permanently, and all existing progress will be lost.",
+    icon: "warning",
+    heightAuto: false,
+    showCancelButton: true,
+    confirmButtonColor: "#3085d6",
+    cancelButtonColor: "#d33",
+    confirmButtonText: "Delete progress file",
+    cancelButtonText: "Cancel",
+    focusCancel: true,
+  });
+  if (result.isConfirmed) {
+    //Get the path of the progress file to delete
+    const progressFilePathToDelete = joinPath(
+      guidedProgressFilePath,
+      progressCardNameToDelete + ".json"
+    );
+
+
+    //delete the progress file
+    if (fs) fs.unlinkSync(progressFilePathToDelete, (err) => console.log(err));
+    else console.warn(`Cannot delete the progress file`)
+
+    //remove the progress card from the DOM
+    progressCard.remove();
+  }
+};

--- a/src/stories/Dashboard.js
+++ b/src/stories/Dashboard.js
@@ -142,7 +142,7 @@ export class Dashboard extends LitElement {
   }
 
 
-  setMain(page, infoPassed = {}){
+  setMain(page, infoPassed = {}, toSave = true) {
 
 
     // Update Previous Page
@@ -154,14 +154,14 @@ export class Dashboard extends LitElement {
     if (previous === page) return // Prevent rerendering the same page
 
     if (previous) {
-      if (previous.info.parent && previous.info.section) previous.save() // Save only on nested pages
+      if (toSave && previous.info.parent && previous.info.section) previous.save() // Save only on nested pages
 
       previous.active = false
     }
 
     // Update Active Page
     this.#active = page
-    const toPass = { ...infoPassed}
+    const toPass = { ...infoPassed }
     if (previous) toPass.globalState = previous.info.globalState
 
     if (info.parent && info.section) {
@@ -252,7 +252,12 @@ export class Dashboard extends LitElement {
 
     if (page) {
       const { id, label } = page.info
-      history.pushState({ page: id, label }, label, (isElectron || isStorybook) ? `?page=${id}` : `${window.location.origin}/${id === '/' ? '' : id}`);
+      const queries = new URLSearchParams(window.location.search)
+      queries.set('page', id)
+      const projectName = queries.get('projectName')
+      const value = (isElectron || isStorybook) ? `?${queries}` : `${window.location.origin}/${id === '/' ? '' : id}?${queries}`
+      console.warn('Setting all queries', value, projectName)
+      history.pushState({ page: id, label, projectName }, label, value);
   }
   }
 

--- a/src/stories/Dashboard.js
+++ b/src/stories/Dashboard.js
@@ -76,7 +76,6 @@ export class Dashboard extends LitElement {
 
   pagesById = {}
   #active;
-  #activeId;
 
   constructor (props = {}) {
     super()
@@ -109,7 +108,7 @@ export class Dashboard extends LitElement {
     window.onpushstate = window.onpopstate = (e) => {
       if(e.state){
         document.title = `${e.state.label} - ${this.name}`
-        this.setMain(this.pagesById[e.state.page], undefined, false)
+        this.setMain(this.pagesById[e.state.page], false)
       }
     }
 
@@ -142,29 +141,31 @@ export class Dashboard extends LitElement {
   }
 
 
-  setMain(page, infoPassed = {}, toSave = true) {
+  setMain(page, toSave = true) {
 
 
     // Update Previous Page
-    // if (page.page) page = page.page
     const info = page.info
     const previous = this.#active
-    // if (!info.next && !info.previous && info.page instanceof HTMLElement) info = this.pagesById[info.page.id] // Get info from a direct page
 
     if (previous === page) return // Prevent rerendering the same page
 
-    if (previous) {
-      if (toSave && previous.info.parent && previous.info.section) previous.save() // Save only on nested pages
+    const isNested = info.parent && info.section
 
+    const toPass = {}
+    if (previous) {
+      if (previous.info.globalState) toPass.globalState = previous.info.globalState // Pass global state over if appropriate
+      if (toSave && previous.info.parent && previous.info.section) previous.save() // Save only on nested pages
       previous.active = false
-    }
+    } 
+    
+    // On initial reload, load global state if you can
+    if (isNested && !('globalState' in toPass)) toPass.globalState = page.load()
 
     // Update Active Page
     this.#active = page
-    const toPass = { ...infoPassed }
-    if (previous) toPass.globalState = previous.info.globalState
 
-    if (info.parent && info.section) {
+    if (isNested) {
       this.subSidebar.sections = this.#getSections(info.parent.info.pages, toPass.globalState) // Update sidebar items (if changed)
       this.subSidebar.active = info.id // Update active item (if changed)
       this.sidebar.hide(true)
@@ -226,7 +227,6 @@ export class Dashboard extends LitElement {
 
     this.main.onTransition = (transition) => {
 
-      console.log('transition', transition)
       if (typeof transition === 'number'){
         const info = this.#active.info
         const sign = Math.sign(transition)
@@ -242,22 +242,19 @@ export class Dashboard extends LitElement {
       Object.entries(pages).forEach((arr) => this.addPage(this.pagesById, arr))
       this.sidebar.pages = pages
 
-      console.log('active', active)
       if (active) this.setAttribute('activePage', active)
   }
 
   #activatePage = (id) => {
     const page = this.getPage(this.pagesById[id])
-    this.#activeId = id
 
     if (page) {
       const { id, label } = page.info
       const queries = new URLSearchParams(window.location.search)
       queries.set('page', id)
-      const projectName = queries.get('projectName')
+      const project = queries.get('project')
       const value = (isElectron || isStorybook) ? `?${queries}` : `${window.location.origin}/${id === '/' ? '' : id}?${queries}`
-      console.warn('Setting all queries', value, projectName)
-      history.pushState({ page: id, label, projectName }, label, value);
+      history.pushState({ page: id, label, project }, label, value);
   }
   }
 

--- a/src/stories/pages/Page.js
+++ b/src/stories/pages/Page.js
@@ -6,7 +6,7 @@ import './guided-mode/GuidedHeader.js'
 import '../Footer.js'
 import '../Button'
 
-import { save } from '../../progress.js'
+import { get, save } from '../../progress.js'
 
 const componentCSS = `
 
@@ -46,6 +46,8 @@ export class Page extends LitElement {
   onTransition = () => {} // User-defined function
 
   save = () => save(this)
+
+  load = (datasetNameToResume = new URLSearchParams(window.location.search).get('project')) => this.info.globalState = get(datasetNameToResume)
 
 //   NOTE: Until the shadow DOM is supported in Storybook, we can't use this render function how we'd intend to.
   render() {

--- a/src/stories/pages/guided-mode/GuidedHome.js
+++ b/src/stories/pages/guided-mode/GuidedHome.js
@@ -4,7 +4,7 @@ import { html } from 'lit';
 import { Page } from '../Page.js';
 import { ProgressCard } from './ProgressCard.js';
 
-import { notyf, startLottie } from '../../../globals.js';
+import { startLottie } from '../../../globals.js';
 import * as progress from '../../../progress.js'
 import { newDataset } from '../../../assets/lotties/index.js';
 
@@ -142,29 +142,10 @@ export class GuidedHomePage extends Page {
   resume = async (resumeProgressButton) => {
     resumeProgressButton.classList.add("loading");
     const datasetNameToResume = resumeProgressButton.parentNode.parentNode.querySelector(".progress-file-name").innerText;
-    const datasetResumeJsonObj = await progress.get(datasetNameToResume);
-
-    // If the dataset had been previously successfully uploaded, check to make sure it exists on Pennsieve still.
-    if (datasetResumeJsonObj["previous-guided-upload-dataset-name"]) {
-      const previouslyUploadedName = datasetResumeJsonObj["previous-guided-upload-dataset-name"];
-      const datasetToResumeExistsOnPennsieve = await checkIfDatasetExistsOnPennsieve(
-        previouslyUploadedName
-      );
-      if (!datasetToResumeExistsOnPennsieve) {
-        notyf.open({
-          type: "error",
-          message: `The dataset ${previouslyUploadedName} was not found on Pennsieve therefore you can no longer modify this dataset via Guided Mode.`,
-          duration: 7000,
-        });
-        resumeProgressButton.classList.remove("loading");
-        return;
-      }
-    }
-
-    this.info.globalState = datasetResumeJsonObj
-
+    const global = this.load(datasetNameToResume)
+   
     //Return the user to the last page they exited on
-    let pageToReturnTo = this.info.globalState["page-before-exit"];
+    let pageToReturnTo = global["page-before-exit"];
     if (pageToReturnTo) this.onTransition(pageToReturnTo)
     else throw new Error("No page to return to")
   }
@@ -172,7 +153,7 @@ export class GuidedHomePage extends Page {
 
   async updated(){
 
-    this.info.globalState = {} // Reset the global information
+    this.info.globalState = {} // Reset global state when navigating back to this page
 
     const htmlBase =  this.shadowRoot ?? this
     // this.content = (this.shadowRoot ?? this).querySelector("#content");
@@ -186,12 +167,12 @@ export class GuidedHomePage extends Page {
 
   const datasetCardsRadioButtonsContainer = htmlBase.querySelector("#guided-div-dataset-cards-radio-buttons");
 
-  const guidedSavedProgressFiles = await progress.getEntries()
+  const guidedSavedProgressFiles = progress.getEntries()
 
   //render progress resumption cards from progress file array on first page of guided mode
   if (guidedSavedProgressFiles.length != 0) {
     datasetCardsRadioButtonsContainer.classList.remove("hidden");
-    const progressFileData = await progress.getAll(guidedSavedProgressFiles);
+    const progressFileData = progress.getAll(guidedSavedProgressFiles);
     this.renderProgressCards(progressFileData);
     htmlBase.querySelector("#guided-button-view-datasets-in-progress").click();
   } else {

--- a/src/stories/pages/guided-mode/GuidedStart.js
+++ b/src/stories/pages/guided-mode/GuidedStart.js
@@ -8,10 +8,11 @@ export class GuidedStartPage extends Page {
 
   constructor(...args) {
     super(...args)
-    this.info.globalState = {} // Reset global state when navigating back to this page
   }
 
   updated() {
+
+    this.info.globalState = {} // Reset global state when navigating back to this page
 
     // this.content = (this.shadowRoot ?? this).querySelector("#content");
     // Handle dropdown text

--- a/src/stories/sidebar.js
+++ b/src/stories/sidebar.js
@@ -113,7 +113,6 @@ export class Sidebar extends LitElement {
 
     const hasName = this.name && this.renderName
     const logoNoName = (this.logo && !hasName)
-    console.log('hasName', hasName, this.renderName)
 
     return html`
     <button type="button" id="sidebarCollapse" class="navbar-btn">


### PR DESCRIPTION
This PR allows for reloading the application while maintaining the project that was selected. This behaves similarly to persistent page rendering and is useful for cases where we are manually checking the behavior of UI components populated by entries from the user.

To ensure this works on the development (browser) build, a version of the save workflow has also been created that takes advantage of the native LocalStorage API instead of storing JSON files on the user's computer.
> **Note:** With this change, the only part of the application that requires Electron is getting the absolute path of files.