### PR TITLE
Improved global state management

### DIFF
--- a/src/progress.js
+++ b/src/progress.js
@@ -37,10 +37,10 @@ export const update = (newDatasetName, previousDatasetName) => {
   });
 }
 
-export const save = (page) => {
+export const save = (page, overrides = {}) => {
 
   const globalState = page.info.globalState
-  let guidedProgressFileName = globalState.project.name
+  let guidedProgressFileName = overrides.globalState?.project?.name ?? globalState.project.name
 
   const params = new URLSearchParams(location.search);
   params.set('project', guidedProgressFileName);
@@ -58,7 +58,8 @@ export const save = (page) => {
 
   //Destination: HOMEDIR/NWBGUIDE/Guided-Progress
   globalState["last-modified"] = new Date();
-  globalState["page-before-exit"] = page.info.id;
+  globalState["page-before-exit"] = overrides.id ?? page.info.id;
+  console.log('BEFORE EXIT', globalState["page-before-exit"])
 
 
   var guidedFilePath = joinPath(guidedProgressFilePath, guidedProgressFileName + ".json");

--- a/src/stories/Dashboard.js
+++ b/src/stories/Dashboard.js
@@ -108,7 +108,7 @@ export class Dashboard extends LitElement {
     window.onpushstate = window.onpopstate = (e) => {
       if(e.state){
         document.title = `${e.state.label} - ${this.name}`
-        this.setMain(this.pagesById[e.state.page], false)
+        this.setMain(this.pagesById[e.state.page])
       }
     }
 
@@ -141,7 +141,7 @@ export class Dashboard extends LitElement {
   }
 
 
-  setMain(page, toSave = true) {
+  setMain(page) {
 
 
     // Update Previous Page
@@ -155,7 +155,7 @@ export class Dashboard extends LitElement {
     const toPass = {}
     if (previous) {
       if (previous.info.globalState) toPass.globalState = previous.info.globalState // Pass global state over if appropriate
-      if (toSave && previous.info.parent && previous.info.section) previous.save() // Save only on nested pages
+      if (previous.info.parent && previous.info.section) previous.save(isNested ? page.info : undefined) // Auto-save on nested pages (with info overrides for appropriate redirect)
       previous.active = false
     }
 

--- a/src/stories/pages/Page.js
+++ b/src/stories/pages/Page.js
@@ -45,7 +45,7 @@ export class Page extends LitElement {
 
   onTransition = () => {} // User-defined function
 
-  save = () => save(this)
+  save = (overrides) => save(this, overrides)
 
   load = (datasetNameToResume = new URLSearchParams(window.location.search).get('project')) => this.info.globalState = get(datasetNameToResume)
 

--- a/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
+++ b/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
@@ -61,6 +61,8 @@ export class GuidedNewDatasetPage extends Page {
 
   render() {
 
+    this.state = {} // Clear local state on each render
+
     let projectGlobalState = this.info.globalState.project
     if (!projectGlobalState) projectGlobalState = this.info.globalState.project = {}
 


### PR DESCRIPTION
This PR fixes a few issues with global state management, including: 

1. Auto-save state when transitioning pages
2. Save the path of the page you're going to—not the one you're coming from
3. Clear the New Project Info page so there is no persistent metadata if leaving the page