### PR TITLE
Sort JSONSchemaForm

### DIFF
--- a/src/stories/JSONSchemaForm.js
+++ b/src/stories/JSONSchemaForm.js
@@ -556,7 +556,35 @@ export class JSONSchemaForm extends LitElement {
 
     return renderable.length === 0 ?
       html`<p>No properties to render</p>` :
-      renderable.map(([name, info]) => {
+      renderable
+
+      // Sort alphabetically
+      .sort(([name], [name2])=> {
+        if (name < name2) {
+          return -1;
+        }
+        if (name > name2) {
+          return 1;
+        }
+        return 0;
+      })
+
+      // Sort required properties to the top
+      .sort(([name], [name2]) => {
+        if (required[name] && !required[name2]) return -1 // first required
+        if (!required[name] && required[name2]) return 1 // second required
+        return 0 // Both required
+      })
+
+       // Prioritise properties without other properties
+      .sort(([_, info], [__, info2]) => {
+        if (!info.properties && !info2.properties) return 0
+        else if (!info.properties) return -1
+        else if (!info2.properties) return 1
+      })
+
+      // Render each property
+      .map(([name, info]) => {
 
 
       // Directly render the interactive property element


### PR DESCRIPTION
This PR sorts the JSONSchema form so that entries are sorted (1) alphabetically, (2) as required or not, and (3) whether they are inputs or another level of properties.

This leads to forms where hierarchies are well-defined, required properties filter to the top, and required / non-required properties are separately presented alphabetically.