### PR TITLE
Fix conversion behavior which requires interfaces to be passed

### DIFF
--- a/src/stories/pages/guided-mode/options/GuidedConversionOptions.js
+++ b/src/stories/pages/guided-mode/options/GuidedConversionOptions.js
@@ -31,7 +31,10 @@ export class GuidedConversionOptionsPage extends Page {
         interfaces: this.info.globalState.source.interfaces
       })
 
-      .catch(e => this.notify(e.message, 'error'))
+      .catch(e => {
+        this.notify(e.message, 'error')
+        throw e.message
+      })
 
       this.info.globalState.preview = results // Save the preview results
 

--- a/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -27,7 +27,10 @@ export class GuidedStubPreviewPage extends Page {
         interfaces: this.info.globalState.source.interfaces
       })
 
-      .catch(e => this.notify(e.message, 'error'))
+      .catch(e => {
+        this.notify(e.message, 'error')
+        throw e.message
+      })
 
       this.info.globalState.conversion.results = results
 

--- a/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -23,7 +23,8 @@ export class GuidedStubPreviewPage extends Page {
 
         // Override with the lastest source data and metadata information
         source_data: this.info.globalState.source.results,
-        metadata: this.info.globalState.metadata.results
+        metadata: this.info.globalState.metadata.results,
+        interfaces: this.info.globalState.source.interfaces
       })
 
       .catch(e => this.notify(e.message, 'error'))


### PR DESCRIPTION
Pass interfaces to the final conversion to avoid server-side error. Additionally, block transitions if an error occurs.