### PR TITLE
Update footer buttons to indicate save behavior

### DIFF
--- a/src/stories/Main.js
+++ b/src/stories/Main.js
@@ -94,6 +94,9 @@ export class Main extends LitElement {
         else footer = true
       }
 
+      if (footer === true) footer = {}
+      if (footer && 'onNext' in footer && !('next' in footer)) footer.next = "Save and Continue"
+
       // Default Capsules Behavior
       const section = sections[info.section]
       if (section) {

--- a/src/stories/pages/guided-mode/options/GuidedConversionOptions.js
+++ b/src/stories/pages/guided-mode/options/GuidedConversionOptions.js
@@ -71,11 +71,6 @@ export class GuidedConversionOptionsPage extends Page {
       }
     })
 
-
-    const convertButton = document.createElement('nwb-button')
-    convertButton.textContent = 'Run Conversion Preview'
-    convertButton.addEventListener('click', this.footer.onNext)
-
     return html`
   <div
     id="guided-mode-starting-container"
@@ -88,8 +83,6 @@ export class GuidedConversionOptionsPage extends Page {
       <div class="guided--section">
       <h3>NWB File Path</h3>
       ${this.form}
-      <br>
-      ${convertButton}
       </div>
   </div>
     `;

--- a/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -36,10 +36,6 @@ export class GuidedStubPreviewPage extends Page {
 
   render() {
 
-    const convertButton = document.createElement('nwb-button')
-    convertButton.textContent = 'Run Full Conversion'
-    convertButton.addEventListener('click', this.footer.onNext)
-
     return html`
   <div
     id="guided-mode-starting-container"
@@ -51,8 +47,6 @@ export class GuidedStubPreviewPage extends Page {
       </div>
       <div class="guided--section">
       ${this.info.globalState.preview ? html`<pre>${this.info.globalState.preview}</pre>`: html`<p>Your conversion preview failed. Please try again.</p>`}
-      <br>
-      ${convertButton}
       </div>
   </div>
     `;


### PR DESCRIPTION
![Screenshot 2023-04-17 at 11 48 15 AM](https://user-images.githubusercontent.com/46533749/232582367-b24a614a-aa26-427d-9ca8-a83c3bdbf437.png)

Instead of "Next", "Save and Continue" is rendered if custom button text (e.g. "Run Conversion") is not provided.
