### PR TITLE
Hide DANDI API key

### DIFF
--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
@@ -36,6 +36,7 @@ export class GuidedUploadPage extends Page {
             properties: {
                 api_key: {
                     type: "string",
+                    format: 'password'
                 },
                 dandiset_id: {
                     type: "string",

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
@@ -36,7 +36,7 @@ export class GuidedUploadPage extends Page {
             properties: {
                 api_key: {
                     type: "string",
-                    format: 'password'
+                    format: "password",
                 },
                 dandiset_id: {
                     type: "string",


### PR DESCRIPTION
In preparation for the demo video, this PR hides the DANDI API key using a native password input (i.e. xyz is rendered as ***)