### PR TITLE
Show all neuroconv interfaces

### DIFF
--- a/guideGlobalMetadata.json
+++ b/guideGlobalMetadata.json
@@ -1,0 +1,6 @@
+{
+    "supported_interfaces": [
+        "SpikeGLXRecordingInterface", 
+        "PhySortingInterface"
+    ]
+}

--- a/guideGlobalMetadata.json
+++ b/guideGlobalMetadata.json
@@ -1,6 +1,6 @@
 {
     "supported_interfaces": [
-        "SpikeGLXRecordingInterface", 
+        "SpikeGLXRecordingInterface",
         "PhySortingInterface"
     ]
 }

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1,5 +1,5 @@
 from typing import List, Dict, Optional, Union
-from neuroconv.datainterfaces import SpikeGLXRecordingInterface, PhySortingInterface
+from neuroconv.datainterfaces import interface_list #, SpikeGLXRecordingInterface, PhySortingInterface
 from neuroconv import datainterfaces, NWBConverter
 from neuroconv.datainterfaces.ecephys.baserecordingextractorinterface import BaseRecordingExtractorInterface
 
@@ -63,7 +63,7 @@ def get_all_interface_info() -> dict:
     """Format an information structure to be used for selecting interfaces based on modality and technique."""
 
     # Hard coded for now - eventual goal will be to import this from NeuroConv
-    hardcoded_interfaces = dict(SpikeGLX=SpikeGLXRecordingInterface, Phy=PhySortingInterface)
+    interfaces_to_load = {interface.__name__.replace("Interface", ""): interface for interface in interface_list} # dict(SpikeGLX=SpikeGLXRecordingInterface, Phy=PhySortingInterface)
 
     return {
         interface.__name__: {
@@ -72,7 +72,7 @@ def get_all_interface_info() -> dict:
             "label": format_name
             # Can also add a description here if we want to provide more information about the interface
         }
-        for format_name, interface in hardcoded_interfaces.items()
+        for format_name, interface in interfaces_to_load.items()
     }
 
 

--- a/src/renderer/src/globals.js
+++ b/src/renderer/src/globals.js
@@ -1,6 +1,6 @@
 import { path, port } from "./electron/index.js";
 
-import guideGlobalMetadata from '../../../guideGlobalMetadata.json' assert {type: 'json'}
+import guideGlobalMetadata from "../../../guideGlobalMetadata.json" assert { type: "json" };
 
 export const joinPath = (...args) => (path ? path.join(...args) : args.filter((str) => str).join("/"));
 
@@ -12,5 +12,4 @@ export let runOnLoad = (fn) => {
 // Base Request URL for Python Server
 export const baseUrl = `http://127.0.0.1:${port}`;
 
-
-export const supportedInterfaces = guideGlobalMetadata.supported_interfaces
+export const supportedInterfaces = guideGlobalMetadata.supported_interfaces;

--- a/src/renderer/src/globals.js
+++ b/src/renderer/src/globals.js
@@ -1,5 +1,7 @@
 import { path, port } from "./electron/index.js";
 
+import guideGlobalMetadata from '../../../guideGlobalMetadata.json' assert {type: 'json'}
+
 export const joinPath = (...args) => (path ? path.join(...args) : args.filter((str) => str).join("/"));
 
 export let runOnLoad = (fn) => {
@@ -9,3 +11,6 @@ export let runOnLoad = (fn) => {
 
 // Base Request URL for Python Server
 export const baseUrl = `http://127.0.0.1:${port}`;
+
+
+export const supportedInterfaces = guideGlobalMetadata.supported_interfaces

--- a/src/renderer/src/stories/Search.js
+++ b/src/renderer/src/stories/Search.js
@@ -61,6 +61,11 @@ export class Search extends LitElement {
             .label {
                 margin: 0;
             }
+
+            [disabled] {
+                pointer-events: none;
+                opacity: 0.4;
+            }
         `;
     }
 
@@ -106,12 +111,25 @@ export class Search extends LitElement {
         this.list.appendChild(slot);
 
         if (this.options) {
-            this.options.forEach((option) => {
+            this.options
+                .sort((a, b) => {
+                    if (a.label < b.label) return -1;
+                    if (a.label > b.label) return 1;
+                    return 0;
+                }) // Sort alphabetically
+                .sort((a,b) => {
+                    if (a.disabled && b.disabled) return 0
+                    else if (a.disabled) return 1
+                    else if (b.disabled) return -1
+                }) // Sort with the disabled options at the bottom
+                .forEach((option) => {
                 const li = document.createElement("li");
                 li.classList.add("option");
                 li.setAttribute("hidden", "");
                 li.setAttribute("data-keywords", JSON.stringify(option.keywords));
                 li.addEventListener("click", () => this.#onSelect(option));
+
+                if (option.disabled) li.setAttribute('disabled', '')
 
                 const label = document.createElement("h4");
                 label.classList.add("label");

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
@@ -134,7 +134,13 @@ export class GuidedStructurePage extends Page {
     };
 
     async updated() {
+
         const selected = this.info.globalState.interfaces;
+
+        const accepted = [
+            "SpikeGLXRecordingInterface", 
+            "PhySortingInterface"
+        ]
 
         this.search.options = await fetch(`${baseUrl}/neuroconv`)
             .then((res) => res.json())
@@ -144,6 +150,7 @@ export class GuidedStructurePage extends Page {
                         ...value,
                         key: key.replace("Interface", ""),
                         value: key,
+                        disabled: !accepted.includes(key)
                     }; // Has label and keywords property already
                 })
             )

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
@@ -144,7 +144,7 @@ export class GuidedStructurePage extends Page {
                         ...value,
                         key: key.replace("Interface", ""),
                         value: key,
-                        disabled: !supportedInterfaces.includes(key)
+                        disabled: !supportedInterfaces.includes(key),
                     }; // Has label and keywords property already
                 })
             )

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
@@ -3,7 +3,7 @@ import { Page } from "../../Page.js";
 
 // For Multi-Select Form
 import { Button } from "../../../Button.js";
-import { baseUrl } from "../../../../globals.js";
+import { baseUrl, supportedInterfaces } from "../../../../globals.js";
 import { Search } from "../../../Search.js";
 import { Modal } from "../../../Modal";
 
@@ -137,11 +137,6 @@ export class GuidedStructurePage extends Page {
 
         const selected = this.info.globalState.interfaces;
 
-        const accepted = [
-            "SpikeGLXRecordingInterface", 
-            "PhySortingInterface"
-        ]
-
         this.search.options = await fetch(`${baseUrl}/neuroconv`)
             .then((res) => res.json())
             .then((json) =>
@@ -150,7 +145,7 @@ export class GuidedStructurePage extends Page {
                         ...value,
                         key: key.replace("Interface", ""),
                         value: key,
-                        disabled: !accepted.includes(key)
+                        disabled: !supportedInterfaces.includes(key)
                     }; // Has label and keywords property already
                 })
             )


### PR DESCRIPTION
This PR opens up the interfaces provided to the GUIDE on the backend and instead limits the valid options on the frontend. 

This allows us to display the full list of interfaces we intend to support while ensuring users can only select the ones we've validated.