### PR TITLE
Fix state updates, rendering, and saving

### DIFF
--- a/src/renderer/src/progress.js
+++ b/src/renderer/src/progress.js
@@ -42,9 +42,9 @@ export const save = (page, overrides = {}) => {
 
     params.set("project", guidedProgressFileName);
 
+    // Update browser history state
     const value = `${location.pathname}?${params}`;
-    history.state.project = guidedProgressFileName;
-
+    if (history.state) history.state.project = guidedProgressFileName;
     window.history.pushState(history.state, null, value);
 
     //Destination: HOMEDIR/NWBGUIDE/Guided-Progress

--- a/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
+++ b/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
@@ -8,7 +8,6 @@ export class GuidedStartPage extends Page {
     }
 
     updated() {
-        
         // this.content = (this.shadowRoot ?? this).querySelector("#content");
         // Handle dropdown text
         const infoDropdowns = (this.shadowRoot ?? this).getElementsByClassName("guided--info-dropdown");

--- a/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
+++ b/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
@@ -8,8 +8,7 @@ export class GuidedStartPage extends Page {
     }
 
     updated() {
-        this.info.globalState = {}; // Reset global state when navigating back to this page
-
+        
         // this.content = (this.shadowRoot ?? this).querySelector("#content");
         // Handle dropdown text
         const infoDropdowns = (this.shadowRoot ?? this).getElementsByClassName("guided--info-dropdown");

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
@@ -73,7 +73,7 @@ export class GuidedNewDatasetPage extends Page {
         const schema = { ...projectMetadataSchema };
         schema.properties = { ...schema.properties };
 
-        this.state = structuredClone(this.info.globalState.project)
+        this.state = structuredClone(this.info.globalState.project);
 
         const pages = schemaToPages.call(this, schema, ["project"], { validateEmptyValues: false });
 

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
@@ -73,6 +73,8 @@ export class GuidedNewDatasetPage extends Page {
         const schema = { ...projectMetadataSchema };
         schema.properties = { ...schema.properties };
 
+        this.state = structuredClone(this.info.globalState.project)
+
         const pages = schemaToPages.call(this, schema, ["project"], { validateEmptyValues: false });
 
         pages.forEach((page) => this.addPage(page.info.label, page));


### PR DESCRIPTION
This PR fixes some issues with global state updates that were not rendering and saving properly.

The changes are as follows: 
1. No longer clear the global state when users go to the `guided/start`, which provides some information about the workflow
2. Check that the page history has a state before trying to write to it
3. Set the local state for the `guided/details` page so that `name` always renders and isn't cleared when going back to this page