### PR TITLE
Add link to path expansion documentation

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -191,9 +191,9 @@ function initialize() {
   function createWindow() {
     // mainWindow.webContents.openDevTools();
 
-    mainWindow.webContents.on("new-window", (event, url) => {
-      event.preventDefault();
+    mainWindow.webContents.setWindowOpenHandler(({ url }) => {
       shell.openExternal(url);
+      return { action: 'deny' };
     });
 
     mainWindow.webContents.once("dom-ready", () => {

--- a/src/renderer/src/links.js
+++ b/src/renderer/src/links.js
@@ -1,7 +1,0 @@
-import { electron } from "./electron/index.js";
-const { shell } = electron;
-
-export const openLink = (url) => {
-    if (shell) shell.openExternal(url);
-    else window.open(url, "_blank");
-};

--- a/src/renderer/src/stories/Accordion.js
+++ b/src/renderer/src/stories/Accordion.js
@@ -9,7 +9,7 @@ import {
     warningSymbol,
 } from "./globals";
 
-import { Chevron } from './Chevron'
+import { Chevron } from "./Chevron";
 
 // import 'fa-icons';
 
@@ -45,7 +45,7 @@ export class Accordion extends LitElement {
             .header > *:nth-child(2) {
                 padding-bottom: 2px;
             }
-            
+
             nwb-chevron {
                 margin: 10px;
             }
@@ -198,7 +198,7 @@ export class Accordion extends LitElement {
 
         //toggle the chevron
         const chevron = dropdown.querySelector("nwb-chevron");
-        chevron.direction = state ? "bottom" : "right"
+        chevron.direction = state ? "bottom" : "right";
 
         this.sections[sectionName].open = state;
     };
@@ -220,9 +220,9 @@ export class Accordion extends LitElement {
                                         <small>${info.subtitle}</small>
                                     </div>
                                     ${new Chevron({
-                                        direction: 'right',
+                                        direction: "right",
                                         color: faColor,
-                                        size: faSize
+                                        size: faSize,
                                     })}
                                 </div>
                                 <div

--- a/src/renderer/src/stories/Accordion.js
+++ b/src/renderer/src/stories/Accordion.js
@@ -9,6 +9,8 @@ import {
     warningSymbol,
 } from "./globals";
 
+import { Chevron } from './Chevron'
+
 // import 'fa-icons';
 
 const faSize = "1em";
@@ -28,34 +30,6 @@ export class Accordion extends LitElement {
                 white-space: nowrap;
             }
 
-            .chevron {
-                padding: 0 10px;
-                transform: translateY(-3px);
-            }
-
-            .chevron::before {
-                border-style: solid;
-                border-width: 0.23em 0.23em 0 0;
-                content: "";
-                display: inline-block;
-                height: 0.45em;
-                transform: rotate(-45deg);
-                vertical-align: middle;
-                width: 0.45em;
-            }
-
-            .chevron.right:before {
-                left: 0;
-                position: relative;
-                top: 0.15em;
-                transform: rotate(45deg);
-            }
-
-            .chevron.bottom:before {
-                top: 0;
-                transform: rotate(135deg);
-            }
-
             .header > * {
                 line-height: initial;
                 margin: 0;
@@ -70,6 +44,10 @@ export class Accordion extends LitElement {
 
             .header > *:nth-child(2) {
                 padding-bottom: 2px;
+            }
+            
+            nwb-chevron {
+                margin: 10px;
             }
 
             .guided--nav-bar-section {
@@ -219,10 +197,8 @@ export class Accordion extends LitElement {
         this.#updateClass("active", dropdown, !state);
 
         //toggle the chevron
-        const chevron = dropdown.querySelector(".chevron");
-
-        chevron.classList.add(state ? "bottom" : "right");
-        chevron.classList.remove(state ? "right" : "bottom");
+        const chevron = dropdown.querySelector("nwb-chevron");
+        chevron.direction = state ? "bottom" : "right"
 
         this.sections[sectionName].open = state;
     };
@@ -243,7 +219,11 @@ export class Accordion extends LitElement {
                                         <span>${sectionName}</span>
                                         <small>${info.subtitle}</small>
                                     </div>
-                                    <div class="chevron right" color="${faColor}" size="${faSize}"></div>
+                                    ${new Chevron({
+                                        direction: 'right',
+                                        color: faColor,
+                                        size: faSize
+                                    })}
                                 </div>
                                 <div
                                     data-section="${sectionName}"

--- a/src/renderer/src/stories/Chevron.js
+++ b/src/renderer/src/stories/Chevron.js
@@ -1,22 +1,20 @@
 import { LitElement, css, html } from "lit";
 
 export class Chevron extends LitElement {
-
     static get styles() {
         return css`
+            :host {
+                transition: 0.5s;
+            }
 
-        :host {
-            transition: 0.5s;
-        }
+            div {
+                transform: translateY(-3px);
+            }
 
-        div {
-            transform: translateY(-3px);
-        }
-
-        div::before {
+            div::before {
                 border-style: solid;
                 border-width: 0.25em 0.25em 0 0;
-                content: '';
+                content: "";
                 display: inline-block;
                 height: 0.45em;
                 left: 0.15em;
@@ -25,52 +23,49 @@ export class Chevron extends LitElement {
                 transform: rotate(-45deg);
                 vertical-align: top;
                 width: 0.45em;
-        }
+            }
 
-        :host([direction=right]) div:before {
-            left: 0;
-            position: relative;
-            top: 0.60em;
-            transform: rotate(45deg);
-        }
+            :host([direction="right"]) div:before {
+                left: 0;
+                position: relative;
+                top: 0.6em;
+                transform: rotate(45deg);
+            }
 
-        :host([direction=bottom]) div:before {
-            top: 0;
-            top: 0.50em;
-            transform: rotate(135deg);
-        }
+            :host([direction="bottom"]) div:before {
+                top: 0;
+                top: 0.5em;
+                transform: rotate(135deg);
+            }
 
-        :host([direction=left]) div:before {
-            left: 0.25em;
-            top: 0.60em;
-	        transform: rotate(-135deg);
-        }
-        `
+            :host([direction="left"]) div:before {
+                left: 0.25em;
+                top: 0.6em;
+                transform: rotate(-135deg);
+            }
+        `;
     }
 
     static get properties() {
         return {
             direction: {
                 type: String,
-                reflect: true
-            }
-        }
+                reflect: true,
+            },
+        };
     }
 
-    constructor({ direction, size, color } = {}){
-        super()
+    constructor({ direction, size, color } = {}) {
+        super();
 
-        this.direction = direction ?? 'right'
-        this.size = size
-        this.color = color
+        this.direction = direction ?? "right";
+        this.size = size;
+        this.color = color;
     }
 
     render() {
-        return html`
-            <div color="${this.size}" size="${this.size}"></div>
-        `
+        return html` <div color="${this.size}" size="${this.size}"></div> `;
     }
 }
 
-customElements.get("nwb-chevron") ||
-    customElements.define("nwb-chevron", Chevron);
+customElements.get("nwb-chevron") || customElements.define("nwb-chevron", Chevron);

--- a/src/renderer/src/stories/Chevron.js
+++ b/src/renderer/src/stories/Chevron.js
@@ -1,0 +1,76 @@
+import { LitElement, css, html } from "lit";
+
+export class Chevron extends LitElement {
+
+    static get styles() {
+        return css`
+
+        :host {
+            transition: 0.5s;
+        }
+
+        div {
+            transform: translateY(-3px);
+        }
+
+        div::before {
+                border-style: solid;
+                border-width: 0.25em 0.25em 0 0;
+                content: '';
+                display: inline-block;
+                height: 0.45em;
+                left: 0.15em;
+                position: relative;
+                top: 0.8em;
+                transform: rotate(-45deg);
+                vertical-align: top;
+                width: 0.45em;
+        }
+
+        :host([direction=right]) div:before {
+            left: 0;
+            position: relative;
+            top: 0.60em;
+            transform: rotate(45deg);
+        }
+
+        :host([direction=bottom]) div:before {
+            top: 0;
+            top: 0.50em;
+            transform: rotate(135deg);
+        }
+
+        :host([direction=left]) div:before {
+            left: 0.25em;
+            top: 0.60em;
+	        transform: rotate(-135deg);
+        }
+        `
+    }
+
+    static get properties() {
+        return {
+            direction: {
+                type: String,
+                reflect: true
+            }
+        }
+    }
+
+    constructor({ direction, size, color } = {}){
+        super()
+
+        this.direction = direction ?? 'right'
+        this.size = size
+        this.color = color
+    }
+
+    render() {
+        return html`
+            <div color="${this.size}" size="${this.size}"></div>
+        `
+    }
+}
+
+customElements.get("nwb-chevron") ||
+    customElements.define("nwb-chevron", Chevron);

--- a/src/renderer/src/stories/InfoBox.js
+++ b/src/renderer/src/stories/InfoBox.js
@@ -2,10 +2,8 @@ import { LitElement, css, html } from "lit";
 import { Chevron } from "./Chevron";
 
 export class InfoBox extends LitElement {
-
     static get styles() {
         return css`
-
             @keyframes demo-box-fade-in {
                 0% {
                     opacity: 0;
@@ -49,7 +47,6 @@ export class InfoBox extends LitElement {
                 color: #000;
             }
 
-
             .guided--info-container {
                 background-color: var(--color-transparent-soda-green);
 
@@ -70,32 +67,31 @@ export class InfoBox extends LitElement {
                 font-size: 13px;
                 color: hsl(0, 0%, 22%);
             }
-            
+
             .container-open {
                 display: flex;
                 margin-bottom: 0px;
                 animation: demo-box-fade-in 0.2s cubic-bezier(0, 0.2, 0.2, 0.96);
             }
-        `
+        `;
     }
 
-    constructor({ header = "Info", content, type = 'info'} = {}){
-        super()
-        this.header = header
-        this.content = content
-        this.type = type
+    constructor({ header = "Info", content, type = "info" } = {}) {
+        super();
+        this.header = header;
+        this.content = content;
+        this.type = type;
     }
 
     updated() {
-
         const infoDropdowns = this.shadowRoot.querySelectorAll(".guided--info-dropdown");
         for (const infoDropdown of Array.from(infoDropdowns)) {
-
             const infoTextElement = infoDropdown.querySelector("#header");
 
             // Auto-add icons if they're not there
             if (this.type === "info") infoTextElement.insertAdjacentHTML("beforebegin", `<span class="icon">ℹ️</span>`);
-            if (this.type === "warning") infoTextElement.insertAdjacentHTML("beforebegin", ` <span class="icon">⚠️</span>`);
+            if (this.type === "warning")
+                infoTextElement.insertAdjacentHTML("beforebegin", ` <span class="icon">⚠️</span>`);
 
             infoDropdown.onclick = () => {
                 const infoContainer = infoDropdown.nextElementSibling;
@@ -104,10 +100,10 @@ export class InfoBox extends LitElement {
                 const infoContainerIsopen = infoContainer.classList.contains("container-open");
 
                 if (infoContainerIsopen) {
-                    infoContainerChevron.direction = 'right';
+                    infoContainerChevron.direction = "right";
                     infoContainer.classList.remove("container-open");
                 } else {
-                    infoContainerChevron.direction = 'bottom';
+                    infoContainerChevron.direction = "bottom";
                     infoContainer.classList.add("container-open");
                 }
             };
@@ -117,17 +113,14 @@ export class InfoBox extends LitElement {
     render() {
         return html`
             <div class="guided--info-dropdown">
-            <span id="header">
-                ${this.header}
-            </span>
-            ${new Chevron({ direction: 'right' })}
+                <span id="header"> ${this.header} </span>
+                ${new Chevron({ direction: "right" })}
             </div>
             <div class="guided--info-container">
                 <span class="guided--help-text">${this.content}</span>
             </div>
-        `
+        `;
     }
 }
 
-customElements.get("nwbguide-info-box") ||
-    customElements.define("nwbguide-info-box", InfoBox);
+customElements.get("nwbguide-info-box") || customElements.define("nwbguide-info-box", InfoBox);

--- a/src/renderer/src/stories/InfoBox.js
+++ b/src/renderer/src/stories/InfoBox.js
@@ -1,0 +1,133 @@
+import { LitElement, css, html } from "lit";
+import { Chevron } from "./Chevron";
+
+export class InfoBox extends LitElement {
+
+    static get styles() {
+        return css`
+
+            @keyframes demo-box-fade-in {
+                0% {
+                    opacity: 0;
+                    transform: translateY(-20px);
+                }
+                100% {
+                    opacity: 1;
+                    transform: translateY(0);
+                }
+            }
+
+            :host {
+                display: inline-block;
+                width: 100%;
+            }
+
+            .icon {
+                margin-right: 10px;
+                font-size: 12px;
+                color: #000;
+            }
+
+            nwb-chevron {
+                transform: scale(70%);
+                margin-left: 5px;
+            }
+
+            .guided--info-dropdown {
+                display: flex;
+                align-self: flex-start;
+                flex-wrap: nowrap;
+                justify-content: start;
+                align-items: center;
+                cursor: pointer;
+            }
+
+            #header {
+                margin: 0px;
+                font-weight: 500;
+                font-size: 12px;
+                color: #000;
+            }
+
+
+            .guided--info-container {
+                background-color: var(--color-transparent-soda-green);
+
+                margin-top: 5px;
+                padding: 10px;
+
+                display: none;
+                flex-direction: column;
+                justify-content: center;
+
+                text-align: justify;
+
+                border: 1px solid var(--color-light-green);
+                border-radius: 3px;
+            }
+
+            .guided--info-container .guided--help-text {
+                font-size: 13px;
+                color: hsl(0, 0%, 22%);
+            }
+            
+            .container-open {
+                display: flex;
+                margin-bottom: 0px;
+                animation: demo-box-fade-in 0.2s cubic-bezier(0, 0.2, 0.2, 0.96);
+            }
+        `
+    }
+
+    constructor({ header = "Info", content, type = 'info'} = {}){
+        super()
+        this.header = header
+        this.content = content
+        this.type = type
+    }
+
+    updated() {
+
+        const infoDropdowns = this.shadowRoot.querySelectorAll(".guided--info-dropdown");
+        for (const infoDropdown of Array.from(infoDropdowns)) {
+
+            const infoTextElement = infoDropdown.querySelector("#header");
+
+            // Auto-add icons if they're not there
+            if (this.type === "info") infoTextElement.insertAdjacentHTML("beforebegin", `<span class="icon">ℹ️</span>`);
+            if (this.type === "warning") infoTextElement.insertAdjacentHTML("beforebegin", ` <span class="icon">⚠️</span>`);
+
+            infoDropdown.onclick = () => {
+                const infoContainer = infoDropdown.nextElementSibling;
+                const infoContainerChevron = infoDropdown.querySelector("nwb-chevron");
+
+                const infoContainerIsopen = infoContainer.classList.contains("container-open");
+
+                if (infoContainerIsopen) {
+                    infoContainerChevron.direction = 'right';
+                    infoContainer.classList.remove("container-open");
+                } else {
+                    infoContainerChevron.direction = 'bottom';
+                    infoContainer.classList.add("container-open");
+                }
+            };
+        }
+    }
+
+    render() {
+        return html`
+            <div class="guided--info-dropdown">
+            <span id="header">
+                ${this.header}
+            </span>
+            ${new Chevron({ direction: 'right' })}
+            </div>
+            <div class="guided--info-container">
+                <span class="guided--help-text">${this.content}</span>
+            </div>
+        `
+    }
+}
+
+customElements.get("nwbguide-info-box") ||
+    customElements.define("nwbguide-info-box", InfoBox);

--- a/src/renderer/src/stories/OptionalSection.js
+++ b/src/renderer/src/stories/OptionalSection.js
@@ -9,6 +9,10 @@ export class OptionalSection extends LitElement {
                 text-align: center;
             }
 
+            h2 {
+                margin: 0;
+            }
+
             .optional-section__content {
                 text-align: left;
             }
@@ -32,7 +36,7 @@ export class OptionalSection extends LitElement {
 
     constructor(props) {
         super();
-        this.title = props.title ?? "";
+        this.header = props.header ?? "";
         this.description = props.description ?? "This is the description of the optional section.";
         this.content = props.content ?? "";
         this.altContent = props.altContent ?? "";
@@ -85,8 +89,8 @@ export class OptionalSection extends LitElement {
         return html`
             <div class="optional-section">
                 <div class="optional-section__header">
-                    ${this.title ? html`<h2 class="optional-section__title">${this.title}</h2>` : ""}
-                    <p class="optional-section__description">${this.description}</p>
+                    ${this.header ? html`<h2>${this.header}</h2>` : ""}
+                    <div>${this.description}</div>
                     <div class="optional-section__toggle">${this.yes} ${this.no}</div>
                 </div>
                 <div class="optional-section__content" hidden>

--- a/src/renderer/src/stories/pages/contact-us/Contact.js
+++ b/src/renderer/src/stories/pages/contact-us/Contact.js
@@ -29,7 +29,7 @@ export class ContactPage extends Page {
                                 <div class="docu-content-container">
                                     <h2 class="document_text">
                                         If you have any issue or suggestions, please email us at
-                                        <a style="text-decoration: underline" href="mailto:help@fairdataihub.org"
+                                        <a style="text-decoration: underline" target="_blank" href="mailto:help@fairdataihub.org"
                                             >help@fairdataihub.org</a
                                         >
                                     </h2>

--- a/src/renderer/src/stories/pages/contact-us/Contact.js
+++ b/src/renderer/src/stories/pages/contact-us/Contact.js
@@ -29,7 +29,10 @@ export class ContactPage extends Page {
                                 <div class="docu-content-container">
                                     <h2 class="document_text">
                                         If you have any issue or suggestions, please email us at
-                                        <a style="text-decoration: underline" target="_blank" href="mailto:help@fairdataihub.org"
+                                        <a
+                                            style="text-decoration: underline"
+                                            target="_blank"
+                                            href="mailto:help@fairdataihub.org"
                                             >help@fairdataihub.org</a
                                         >
                                     </h2>

--- a/src/renderer/src/stories/pages/documentation/Documentation.js
+++ b/src/renderer/src/stories/pages/documentation/Documentation.js
@@ -1,5 +1,4 @@
 import { html } from "lit";
-import { openLink } from "../../../links.js";
 import { docu_lottie } from "../../../../assets/lotties/documentation-lotties.js";
 import { Page } from "../Page.js";
 
@@ -39,9 +38,7 @@ export class DocumentationPage extends Page {
                                             class="view_doc_button sodaVideo-button"
                                             style="margin-top: 1rem"
                                             @click="${() => {
-                                                openLink(
-                                                    "https://docs.sodaforsparc.io/docs/getting-started/organize-and-submit-sparc-datasets-with-soda"
-                                                );
+                                                window.open("https://docs.sodaforsparc.io/docs/getting-started/organize-and-submit-sparc-datasets-with-soda")
                                             }}"
                                         >
                                             View the Documentation

--- a/src/renderer/src/stories/pages/documentation/Documentation.js
+++ b/src/renderer/src/stories/pages/documentation/Documentation.js
@@ -38,7 +38,9 @@ export class DocumentationPage extends Page {
                                             class="view_doc_button sodaVideo-button"
                                             style="margin-top: 1rem"
                                             @click="${() => {
-                                                window.open("https://docs.sodaforsparc.io/docs/getting-started/organize-and-submit-sparc-datasets-with-soda")
+                                                window.open(
+                                                    "https://docs.sodaforsparc.io/docs/getting-started/organize-and-submit-sparc-datasets-with-soda"
+                                                );
                                             }}"
                                         >
                                             View the Documentation

--- a/src/renderer/src/stories/pages/getting-started/GettingStarted.js
+++ b/src/renderer/src/stories/pages/getting-started/GettingStarted.js
@@ -1,7 +1,6 @@
 import { html } from "lit";
 import lottie from "lottie-web";
 import { column1Lottie, column2Lottie, column3Lottie } from "../../../../assets/lotties/overview-lotties.js";
-import { openLink } from "../../../links.js";
 import { Page } from "../Page.js";
 
 import { startLottie } from "../../../dependencies/globals.js";
@@ -56,7 +55,7 @@ export class GettingStartedPage extends Page {
                     <button
                         id="home-button-interface-instructions-link"
                         class="getting-started-btn secondary-plain-button text-base"
-                        @click="${() => openLink("https://www.nwb.org/")}"
+                        @click="${() => window.open("https://www.nwb.org/")}"
                     >
                         <p class="interface-btn-txt">Learn about NWB and DANDI</p>
 

--- a/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
+++ b/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
@@ -63,14 +63,14 @@ export class GuidedStartPage extends Page {
                             of your local data files will ever be modified or moved.
                         </p>
                         ${new InfoBox({
-                            header: 'Learn more about the conversion process',
+                            header: "Learn more about the conversion process",
                             content: html`
-                            Although not required to use Guided Mode, you can learn more about the NWB conversion
-                            process in the
-                            <a href="https://neuroconv.readthedocs.io/en/main" target="_blank"
-                                >neuroconv documentation page</a
-                            >
-                            `
+                                Although not required to use Guided Mode, you can learn more about the NWB conversion
+                                process in the
+                                <a href="https://neuroconv.readthedocs.io/en/main" target="_blank"
+                                    >neuroconv documentation page</a
+                                >
+                            `,
                         })}
                     </div>
                 </div>

--- a/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
+++ b/src/renderer/src/stories/pages/guided-mode/GuidedStart.js
@@ -1,6 +1,7 @@
 import { html } from "lit";
 import { Page } from "../Page.js";
 import "./GuidedFooter";
+import { InfoBox } from "../../InfoBox.js";
 
 export class GuidedStartPage extends Page {
     constructor(...args) {
@@ -61,21 +62,16 @@ export class GuidedStartPage extends Page {
                             generate a valid NWB file and ask for your review before uploading to DANDI. Note that none
                             of your local data files will ever be modified or moved.
                         </p>
-                        <div class="guided--info-dropdown">
-                            <p class="guided--dropdown-text" data-dropdown-type="info">
-                                Learn more about the conversion process
-                            </p>
-                            <i class="fas fa-chevron-right"></i>
-                        </div>
-                        <div class="guided--info-container">
-                            <p class="guided--help-text">
-                                Although not required to use Guided Mode, you can learn more about the NWB conversion
-                                process in the
-                                <a href="https://neuroconv.readthedocs.io/en/main" target="_blank"
-                                    >neuroconv documentation page</a
-                                >.
-                            </p>
-                        </div>
+                        ${new InfoBox({
+                            header: 'Learn more about the conversion process',
+                            content: html`
+                            Although not required to use Guided Mode, you can learn more about the NWB conversion
+                            process in the
+                            <a href="https://neuroconv.readthedocs.io/en/main" target="_blank"
+                                >neuroconv documentation page</a
+                            >
+                            `
+                        })}
                     </div>
                 </div>
             </div>

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -122,8 +122,7 @@ export class GuidedPathExpansionPage extends Page {
 
     optional = new OptionalSection({
         header: "Would you like to locate data programmatically?",
-        description:
-            html`<p>Automatically detect source data for multiple subjects and sessions.</p>`,
+        description: html`<p>Automatically detect source data for multiple subjects and sessions.</p>`,
         // altContent: this.altForm,
     });
 
@@ -144,13 +143,16 @@ export class GuidedPathExpansionPage extends Page {
 
         const form = (this.form = new JSONSchemaForm({ ...structureGlobalState, onThrow }));
 
-
         const pathExpansionInfoBox = new InfoBox({
-            header: 'How do I use a Python format string for path expansion?',
-            content: html`For complete documentation of the path expansion feature of neuroconv, visit the <a href="https://neuroconv.readthedocs.io/en/main/user_guide/expand_path.html" target="_blank">Path Expansion documentation</a> page.`
-        })
+            header: "How do I use a Python format string for path expansion?",
+            content: html`For complete documentation of the path expansion feature of neuroconv, visit the
+                <a href="https://neuroconv.readthedocs.io/en/main/user_guide/expand_path.html" target="_blank"
+                    >Path Expansion documentation</a
+                >
+                page.`,
+        });
 
-        pathExpansionInfoBox.style.margin = '10px 0px'
+        pathExpansionInfoBox.style.margin = "10px 0px";
 
         this.optional.innerHTML = "";
         this.optional.append(pathExpansionInfoBox, form);

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -9,6 +9,7 @@ import { run } from "../options/utils.js";
 import { onThrow } from "../../../../errors";
 
 import pathExpansionSchema from "../../../../../../../schemas/json/path-expansion.schema.json" assert { type: "json" };
+import { InfoBox } from "../../../InfoBox.js";
 
 export class GuidedPathExpansionPage extends Page {
     constructor(...args) {
@@ -120,9 +121,9 @@ export class GuidedPathExpansionPage extends Page {
     // })
 
     optional = new OptionalSection({
-        title: "Would you like to locate data programmatically?",
+        header: "Would you like to locate data programmatically?",
         description:
-            "Locate data using a format string. This will be used to automatically detect source data for multiple subjects and sessions.",
+            html`<p>Automatically detect source data for multiple subjects and sessions.</p>`,
         // altContent: this.altForm,
     });
 
@@ -143,8 +144,16 @@ export class GuidedPathExpansionPage extends Page {
 
         const form = (this.form = new JSONSchemaForm({ ...structureGlobalState, onThrow }));
 
+
+        const pathExpansionInfoBox = new InfoBox({
+            header: 'How do I use a Python format string for path expansion?',
+            content: html`For complete documentation of the path expansion feature of neuroconv, visit the <a href="https://neuroconv.readthedocs.io/en/main/user_guide/expand_path.html" target="_blank">Path Expansion documentation</a> page.`
+        })
+
+        pathExpansionInfoBox.style.margin = '10px 0px'
+
         this.optional.innerHTML = "";
-        this.optional.insertAdjacentElement("afterbegin", form);
+        this.optional.append(pathExpansionInfoBox, form);
 
         form.style.width = "100%";
 


### PR DESCRIPTION
This PR adds a link to the path expansion documentation in an information pop-up similar to that found on `guided/start`. 

To achieve this, an InfoBox component had to be designed that replaced the functionality of the aforementioned HTML elements (which used global styles that are, in many cases, unavailable in other components). 

Additionally, the mechanism for opening external links was improved by fixing the handler in main.ts (the main Electron server process) to allow for opening standard links in another window—a fix for newer Electron versions that our version of SODA seemed to have missed.