### PR TITLE
Fix generated page sizing

### DIFF
--- a/src/renderer/src/stories/pages/FormPage.js
+++ b/src/renderer/src/stories/pages/FormPage.js
@@ -73,14 +73,10 @@ export class GuidedFormPage extends Page {
         form.style.width = "100%";
 
         return html`
-            <div id="guided-mode-starting-container" class="guided--main-tab" data-parent-tab-name="Dataset Structure">
-                <div class="guided--panel" id="guided-intro-page" style="flex-grow: 1">
-                    <div class="title">
-                        <h1 class="guided--text-sub-step">${title ?? label}</h1>
-                    </div>
-                    <div class="guided--section">${form}</div>
-                </div>
+            <div class="title">
+                <h1 class="guided--text-sub-step">${title ?? label}</h1>
             </div>
+            <div class="guided--section">${form}</div>
         `;
     }
 }


### PR DESCRIPTION
This PR ensures that the contents of the generated pages (e.g. NWBFile, Subject) are not bounded with a maxWidth like previous iterations of other pages.