### PR TITLE
Update app copy to accurately reflect behavior and content

### DIFF
--- a/src/renderer/src/pages.js
+++ b/src/renderer/src/pages.js
@@ -84,11 +84,11 @@ style="margin-right: 30px; margin-bottom: -5px"
 
 const pages = {
     "/": new GettingStartedPage({
-        label: "Overview",
+        label: "Home",
         icon: overviewIcon,
     }),
-    guided: new GuidedHomePage({
-        label: "Guided Mode",
+    conversion: new GuidedHomePage({
+        label: "Conversions",
         icon: guidedIcon,
         pages: {
             start: new GuidedStartPage({

--- a/src/renderer/src/stories/pages/GuidedMode.stories.js
+++ b/src/renderer/src/stories/pages/GuidedMode.stories.js
@@ -79,57 +79,57 @@ Home.args = {
 
 export const Start = Template.bind({});
 Start.args = {
-    activePage: "guided/start",
+    activePage: "conversion/start",
 };
 
 export const NewDataset = Template.bind({});
 NewDataset.args = {
-    activePage: "guided/details",
+    activePage: "conversion/details",
 };
 
 export const Structure = Template.bind({});
 Structure.args = {
-    activePage: "guided/structure",
+    activePage: "conversion/structure",
 };
 
 export const Locate = Template.bind({});
 Locate.args = {
-    activePage: "guided/locate",
+    activePage: "conversion/locate",
 };
 
 export const Subjects = Template.bind({});
 Subjects.args = {
-    activePage: "guided/subjects",
+    activePage: "conversion/subjects",
 };
 
 export const SourceData = Template.bind({});
 SourceData.args = {
-    activePage: "guided/sourcedata",
+    activePage: "conversion/sourcedata",
 };
 
 export const Metadata = Template.bind({});
 Metadata.args = {
-    activePage: "guided/metadata",
+    activePage: "conversion/metadata",
 };
 
 export const ConversionOptions = Template.bind({});
 ConversionOptions.args = {
-    activePage: "guided/options",
+    activePage: "conversion/options",
 };
 
 export const StubPreview = Template.bind({});
 StubPreview.args = {
-    activePage: "guided/preview",
+    activePage: "conversion/preview",
 };
 
 export const Upload = Template.bind({});
 Upload.args = {
-    activePage: "guided/upload",
+    activePage: "conversion/upload",
 };
 
 export const Results = Template.bind({});
 Results.args = {
-    activePage: "guided/review",
+    activePage: "conversion/review",
 };
 
 const statefulPages = [

--- a/src/renderer/src/stories/pages/GuidedMode.stories.js
+++ b/src/renderer/src/stories/pages/GuidedMode.stories.js
@@ -2,7 +2,7 @@ import { dashboard } from "../../pages.js";
 import nwbBaseSchema from "../../../../../schemas/base-metadata.schema";
 import exephysExampleSchema from "../../../../../schemas/json/ecephys_metadata_schema_example.json";
 
-const options = Object.keys(dashboard.pagesById).filter((k) => k.includes("guided"));
+const options = Object.keys(dashboard.pagesById).filter((k) => k.includes("conversion"));
 
 export default {
     title: "Pages/Guided Mode",
@@ -74,7 +74,7 @@ const Template = (args = {}) => {
 
 export const Home = Template.bind({});
 Home.args = {
-    activePage: "guided",
+    activePage: "conversion",
 };
 
 export const Start = Template.bind({});

--- a/src/renderer/src/stories/pages/getting-started/GettingStarted.js
+++ b/src/renderer/src/stories/pages/getting-started/GettingStarted.js
@@ -65,7 +65,7 @@ export class GettingStartedPage extends Page {
                     <button
                         id="home-button-guided-mode-link"
                         class="getting-started-btn secondary-plain-button text-base"
-                        @click="${() => this.onTransition("guided")}"
+                        @click="${() => this.onTransition("conversion/start")}"
                     >
                         <p class="getting-started-btn-txt">Convert a new dataset</p>
                         <i class="el-icon icon-animate"

--- a/src/renderer/src/stories/pages/guided-mode/GuidedHome.js
+++ b/src/renderer/src/stories/pages/guided-mode/GuidedHome.js
@@ -223,7 +223,7 @@ export class GuidedHomePage extends Page {
                                     data-next-element="guided-div-resume-progress-cards"
                                     style="width: 250px"
                                 >
-                                    Conversions in Progress
+                                    Existing Conversions
                                 </button>
                             </div>
                         </div>


### PR DESCRIPTION
This PR updates some of the app's text and behavior to ensure that this accurately reflects its behavior.

1. The sidebar options for Overview and Guided Mode have been replaced by Home and Conversions respectively.
    - Relatedly, all `guided/x` paths are now `conversion/x` paths
    - "Guided Mode" is still used to refer to the conversion process, but not the landing page that we use to open it. Since we don't have any other mode to contrast it with, for now, it seems a bit weird to refer to it too often.
2. The Start a New Dataset button on the start page skips the first Conversions page (with the list) and acts as if the user pressed the Convert a New Dataset button on the skipped page
3. The Conversions In Progress tab was replaced with Existing Conversions based on Ben's update to the demo script