### PR TITLE
Add Spike2 Interfaces

### DIFF
--- a/guideGlobalMetadata.json
+++ b/guideGlobalMetadata.json
@@ -3,6 +3,8 @@
         "SpikeGLXRecordingInterface",
         "PhySortingInterface",
         "NeuroScopeSortingInterface",
-        "BiocamRecordingInterface"
+        "BiocamRecordingInterface",
+        "Spike2RecordingInterface",
+        "CEDRecordingInterface"
     ]
 }


### PR DESCRIPTION
This PR adds support for the Spike2RecordingInterface and CEDRecordingInterface.

Based on initial tests, it seems like these interfaces need to be tested on separate pipelines.