### PR TITLE
Delete Ecephys property only if it exists

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -160,7 +160,7 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
         ecephys_properties["ElectrodeColumns"]["items"]["required"] = list(defs["Electrodes"]["properties"].keys())
         del defs["Electrodes"]
 
-    # Delete Ecephys metadata if ElectrodeTable helper function is not available
+    # Delete Ecephys metadata if ElectrodeTable helper function is not available (temporary solution)
     else:
         schema["properties"].pop("Ecephys", {})
 

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -162,7 +162,7 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
 
     # Delete Ecephys metadata if ElectrodeTable helper function is not available
     else:
-        del schema["properties"]["Ecephys"]
+        schema["properties"].pop("Ecephys", {})
 
     return json.loads(json.dumps(dict(results=metadata, schema=schema), cls=NWBMetaDataEncoder))
 

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -447,10 +447,9 @@ export class JSONSchemaForm extends LitElement {
                             @change=${(ev) => this.#validateOnChange(name, parent, ev.target, path)}
                         />`;
                     } else if (info.type === "string" || (isStringArray && !hasItemsRef) || info.type === "number") {
-
-                        let format = info.format
-                        const matched = name.match(/(.+_)?(.+)_path/)
-                        if (!format && matched) format = (matched[2] === 'folder') ? 'directory' : matched[2]
+                        let format = info.format;
+                        const matched = name.match(/(.+_)?(.+)_path/);
+                        if (!format && matched) format = matched[2] === "folder" ? "directory" : matched[2];
 
                         // Handle file and directory formats
                         if (this.#filesystemQueries.includes(format)) {


### PR DESCRIPTION
This PR ensures that the deletion of the Ecephys property will not error if it doesn't exist (e.g. on non-Ecephys interfaces)