### PR TITLE
Show critical errors associated with source data specification

### DIFF
--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -22,7 +22,7 @@ export class GuidedSourceDataPage extends ManagedPage {
 
             this.save(); // Save in case the metadata request fails
 
-            let stillFireSwal = false
+            let stillFireSwal = false;
             const fireSwal = () => {
                 Swal.fire({
                     title: "Getting metadata for source data",
@@ -36,11 +36,11 @@ export class GuidedSourceDataPage extends ManagedPage {
                         Swal.showLoading();
                     },
                 });
-            }
+            };
 
             setTimeout(() => {
-                if (stillFireSwal) fireSwal()
-            })
+                if (stillFireSwal) fireSwal();
+            });
 
             await Promise.all(
                 this.mapSessions(async ({ subject, session, info }) => {
@@ -52,13 +52,14 @@ export class GuidedSourceDataPage extends ManagedPage {
                             source_data: info.source_data,
                             interfaces: this.info.globalState.interfaces,
                         }),
-                    }).then((res) => res.json())
-                    .catch(e => {
-                        Swal.close();
-                        stillFireSwal = false
-                        this.notify(`<b>Critical Error:</b> ${e.message}`, "error", 4000);
-                        throw e
-                    });
+                    })
+                        .then((res) => res.json())
+                        .catch((e) => {
+                            Swal.close();
+                            stillFireSwal = false;
+                            this.notify(`<b>Critical Error:</b> ${e.message}`, "error", 4000);
+                            throw e;
+                        });
 
                     Swal.close();
 


### PR DESCRIPTION
This PR uses the `notify` function to show critical errors associated with source data specification to the user.
![Screenshot 2023-07-13 at 3 56 13 PM](https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/d06ce954-b4b9-47c6-bb44-45cd9c770ab9)
