### PR TITLE
Improved Data Representation

### DIFF
--- a/src/renderer/src/pages.js
+++ b/src/renderer/src/pages.js
@@ -115,7 +115,7 @@ const pages = {
             }),
 
             subjects: new GuidedSubjectsPage({
-                title: "Subjects",
+                title: "Subject Metadata",
                 label: "Subject details",
                 section: sections[0],
             }),

--- a/src/renderer/src/stories/Button.js
+++ b/src/renderer/src/stories/Button.js
@@ -70,7 +70,6 @@ export class Button extends LitElement {
     render() {
         const mode = this.primary ? "storybook-button--primary" : "storybook-button--secondary";
 
-
         return html`
             <button
                 type="button"

--- a/src/renderer/src/stories/InstanceManager.js
+++ b/src/renderer/src/stories/InstanceManager.js
@@ -104,6 +104,11 @@ export class InstanceManager extends LitElement {
                 align-items: center;
             }
 
+            .controls > div {
+                display: flex;
+                gap: 10px;
+            }
+
             #new-info {
                 align-items: unset;
                 width: 100%;
@@ -391,6 +396,7 @@ export class InstanceManager extends LitElement {
                                 return html`<nwb-button
                                     size="small"
                                     icon=${o.icon}
+                                    .primary=${o.primary ?? false}
                                     @click=${function () {
                                         const el = this.shadowRoot.querySelector(
                                             "#instance-display > div:not([hidden])"

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -6,6 +6,8 @@ import { checkStatus } from "../validation";
 import { BasicTable } from "./BasicTable";
 import { capitalize, header, textToArray } from "./forms/utils";
 import { resolve } from "../promises";
+import { merge } from "./pages/utils";
+import { resolveProperties } from "./pages/guided-mode/data/utils";
 
 const componentCSS = `
 
@@ -218,6 +220,10 @@ export class JSONSchemaForm extends LitElement {
               ))
             : this.#rendered;
 
+
+    resolved = {} // Keep track of actual resolved values—not just what the user provides as results
+
+
     constructor(props = {}) {
         super();
 
@@ -227,6 +233,8 @@ export class JSONSchemaForm extends LitElement {
         this.mode = props.mode ?? "default";
         this.schema = props.schema ?? {};
         this.results = props.results ?? {};
+        this.globals = props.globals ?? {};
+
         this.ignore = props.ignore ?? [];
         this.required = props.required ?? {};
         this.dialogOptions = props.dialogOptions ?? {};
@@ -275,9 +283,22 @@ export class JSONSchemaForm extends LitElement {
         if (changedProperties === "options") this.requestUpdate();
     }
 
-    #updateParent(name, value, parent) {
-        if (!value) delete parent[name];
-        else parent[name] = value;
+
+    // Track resolved values for the form
+    #update(fullPath, value) {
+
+        const path = [...fullPath]
+        const name = path.pop()
+        const resultParent = path.reduce((acc, key) => acc[key], this.results)
+        const resolvedParent = path.reduce((acc, key) => acc[key], this.resolved)
+
+        if (!value) {
+            delete resultParent[name];
+            delete resolvedParent[name]
+        } else {
+            resultParent[name] = value;
+            resolvedParent[name] = value
+        }
     }
 
     #addMessage = (name, message, type) => {
@@ -313,7 +334,7 @@ export class JSONSchemaForm extends LitElement {
 
     validate = async () => {
         // Check if any required inputs are missing
-        const invalidInputs = await this.#validateRequirements(this.results, this.#requirements); // get missing required paths
+        const invalidInputs = await this.#validateRequirements(this.resolved, this.#requirements); // get missing required paths
         const isValid = !invalidInputs.length;
 
         // Print out a detailed error message if any inputs are missing
@@ -321,6 +342,7 @@ export class JSONSchemaForm extends LitElement {
 
         // Check if all inputs are valid
         const flaggedInputs = this.shadowRoot ? this.shadowRoot.querySelectorAll(".invalid") : [];
+
         if (flaggedInputs.length) {
             flaggedInputs[0].focus();
             if (!message) message = `${flaggedInputs.length} invalid form values.`;
@@ -361,8 +383,8 @@ export class JSONSchemaForm extends LitElement {
     };
 
     #get = (path) => {
-        path = path.slice(this.#base.length); // Correct for base path
-        return path.reduce((acc, curr) => (acc = acc[curr]), this.results);
+        // path = path.slice(this.#base.length); // Correct for base path
+        return path.reduce((acc, curr) => (acc = acc[curr]), this.resolved);
     };
 
     #checkRequiredAfterChange = async (fullPath) => {
@@ -376,6 +398,8 @@ export class JSONSchemaForm extends LitElement {
 
     #getSchema(path, schema = this.schema) {
         if (typeof path === "string") path = path.split(".");
+
+        // NOTE: Still must correct for the base here
         if (this.#base.length) {
             const base = this.#base.slice(-1)[0];
             const indexOf = path.indexOf(base);
@@ -399,8 +423,13 @@ export class JSONSchemaForm extends LitElement {
             (info.items?.type === "string" || !("items" in info) || (!("type" in info.items) && !hasItemsRef)); // Default to a string type
 
         const fullPath = [...path, name];
-        const isConditional = this.#getLink(fullPath) || typeof isRequired === "function"; // Check the two possible ways of determining if a field is conditional
+        const externalPath = [...this.#base, ...fullPath]
 
+        const resolved = path.reduce((acc, key) => acc[key], this.resolved)
+        const value = resolved[name]
+
+        const isConditional = this.#getLink(externalPath) || typeof isRequired === "function"; // Check the two possible ways of determining if a field is conditional
+        
         if (isConditional && !isRequired)
             isRequired = required[name] = async () => {
                 const isRequiredAfterChange = await this.#checkRequiredAfterChange(fullPath);
@@ -428,13 +457,13 @@ export class JSONSchemaForm extends LitElement {
                         return html`
                             <select
                                 class="guided--input schema-input"
-                                @input=${(ev) => this.#updateParent(name, info.enum[ev.target.value], parent)}
-                                @change=${(ev) => this.#validateOnChange(name, parent, ev.target, path)}
+                                @input=${(ev) => this.#update(fullPath, info.enum[ev.target.value])}
+                                @change=${(ev) => this.#validateOnChange(name, resolved, ev.target, path)}
                             >
                                 <option disabled selected value>Select an option</option>
                                 ${info.enum.map(
                                     (item, i) =>
-                                        html`<option value=${i} ?selected=${parent[name] === item}>${item}</option>`
+                                        html`<option value=${i} ?selected=${value === item}>${item}</option>`
                                 )}
                             </select>
                         `;
@@ -442,18 +471,18 @@ export class JSONSchemaForm extends LitElement {
                         return html`<input
                             type="checkbox"
                             class="schema-input"
-                            @input=${(ev) => this.#updateParent(name, ev.target.checked, parent)}
-                            ?checked=${parent[name] ?? false}
-                            @change=${(ev) => this.#validateOnChange(name, parent, ev.target, path)}
+                            @input=${(ev) => this.#update(fullPath, ev.target.checked)}
+                            ?checked=${value ?? false}
+                            @change=${(ev) => this.#validateOnChange(name, resolved, ev.target, path)}
                         />`;
                     } else if (info.type === "string" || (isStringArray && !hasItemsRef) || info.type === "number") {
                         // Handle file and directory formats
                         if (this.#filesystemQueries.includes(info.format)) {
                             const el = new FilesystemSelector({
                                 type: info.format,
-                                value: parent[name],
-                                onSelect: (filePath) => this.#updateParent(name, filePath, parent),
-                                onChange: (filePath) => this.#validateOnChange(name, parent, el, path),
+                                value,
+                                onSelect: (filePath) => this.#update(fullPath, filePath),
+                                onChange: (filePath) => this.#validateOnChange(name, resolved, el, path),
                                 dialogOptions: this.dialogOptions,
                                 dialogType: this.dialogType,
                             });
@@ -469,18 +498,17 @@ export class JSONSchemaForm extends LitElement {
                                 style="height: 7.5em; padding-bottom: 20px"
                                 maxlength="255"
                                 .value="${isStringArray
-                                    ? parent[name]
-                                        ? parent[name].join("\n")
+                                    ? value
+                                        ? value.join("\n")
                                         : ""
-                                    : parent[name] ?? ""}"
+                                    : value ?? ""}"
                                 @input=${(ev) => {
-                                    this.#updateParent(
-                                        name,
-                                        isStringArray ? textToArray(ev.target.value) : ev.target.value,
-                                        parent
+                                    this.#update(
+                                        fullPath,
+                                        isStringArray ? textToArray(ev.target.value) : ev.target.value
                                     );
                                 }}
-                                @change=${(ev) => this.#validateOnChange(name, parent, ev.target, path)}
+                                @change=${(ev) => this.#validateOnChange(name, resolved, ev.target, path)}
                             ></textarea>`;
                         // Handle other string formats
                         else {
@@ -493,9 +521,9 @@ export class JSONSchemaForm extends LitElement {
                                     class="guided--input schema-input"
                                     type="${type}"
                                     placeholder="${info.placeholder ?? ""}"
-                                    .value="${parent[name] ?? ""}"
-                                    @input=${(ev) => this.#updateParent(name, ev.target.value, parent)}
-                                    @change=${(ev) => this.#validateOnChange(name, parent, ev.target, path)}
+                                    .value="${value ?? ""}"
+                                    @input=${(ev) => this.#update(fullPath, ev.target.value)}
+                                    @change=${(ev) => this.#validateOnChange(name, resolved, ev.target, path)}
                                 />
                             `;
                         }
@@ -506,8 +534,9 @@ export class JSONSchemaForm extends LitElement {
                         if (itemSchema.type === "object") {
                             const tableMetadata = {
                                 schema: itemSchema,
-                                data: parent[name],
-                                validateOnChange: (key, parent, v) => this.validateOnChange(key, parent, fullPath, v),
+                                data: value,
+                                globals: this.globals[name],
+                                validateOnChange: (key, parent, v) => this.validateOnChange(key, parent, fullPath, v), // NOTE: Check whether this parent is accurate
                                 onStatusChange: () => this.#checkStatus(), // Check status on all elements
                                 validateEmptyCells: this.validateEmptyValues,
                                 deferLoading: this.deferLoading,
@@ -564,7 +593,7 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
 
         for (let name in requirements) {
             let isRequired = requirements[name];
-            if (typeof isRequired === "function") isRequired = await isRequired.call(this.results);
+            if (typeof isRequired === "function") isRequired = await isRequired.call(this.resolved);
             if (isRequired) {
                 let path = parent ? `${parent}-${name}` : name;
                 if (typeof isRequired === "object" && !Array.isArray(isRequired))
@@ -579,30 +608,6 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
     // Checks missing required properties and throws an error if any are found
     onInvalid = () => {};
     onLoaded = () => {};
-
-    #registerDefaultProperties = (properties = {}, results) => {
-        for (let name in properties) {
-            const info = properties[name];
-            const props = info.properties;
-
-            if (!results[name]) {
-                if (props) results[name] = {}; // Regisiter new interfaces in results
-                if (info.default) results[name] = info.default;
-            }
-
-            if (props) {
-                Object.entries(props).forEach(([key, value]) => {
-                    if (!(key in results[name])) {
-                        if ("default" in value) results[name][key] = value.default;
-                        else if (value.properties) {
-                            const results = (results[name][key] = {});
-                            this.#registerDefaultProperties(value.properties, results);
-                        }
-                    }
-                });
-            }
-        }
-    };
 
     #deleteExtraneousResults = (results, schema) => {
         for (let name in results) {
@@ -620,7 +625,7 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
             if (this.ignore.includes(key)) return false;
             if (this.showLevelOverride >= path.length) return true;
             if (required[key]) return true;
-            if (this.#getLink([...path, key])) return true;
+            if (this.#getLink([...this.#base, ...path, key])) return true;
             if (!this.onlyRequired) return true;
             return false;
         });
@@ -638,8 +643,8 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
         );
     };
 
-    #applyToLinkedProperties = (fn, args) => {
-        const links = this.#getLink(args)?.properties;
+    #applyToLinkedProperties = (fn, externalPath) => {
+        const links = this.#getLink(externalPath)?.properties;
         if (!links) return [];
         return Promise.all(
             links
@@ -655,8 +660,8 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
     #isLinkResolved = async (pathArr) => {
         return (
             await this.#applyToLinkedProperties((link) => {
-                const isRequired = this.#isRequired(link);
-                if (typeof isRequired === "function") return !isRequired.call(this.results);
+                const isRequired = this.#isRequired(link.slice((this.#base ?? []).length));
+                if (typeof isRequired === "function") return !isRequired.call(this.resolved);
                 else return !isRequired;
             }, pathArr)
         ).reduce((a, b) => a && b, true);
@@ -664,22 +669,25 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
 
     #isRequired = (path) => {
         if (typeof path === "string") path = path.split("-");
-        path = path.slice(this.#base.length); // Remove base path
+        // path = path.slice(this.#base.length); // Remove base path
         return path.reduce((obj, key) => obj && obj[key], this.#requirements);
     };
 
-    #getLinkElement = (path) => {
-        const link = this.#getLink(path);
+    #getLinkElement = (externalPath) => {
+        const link = this.#getLink(externalPath);
         if (!link) return;
         return this.shadowRoot.querySelector(`[data-name="${link.name}"]`);
     };
 
     // Assume this is going to return as a Promise—even if the change function isn't returning one
     #validateOnChange = async (name, parent, element, path = [], checkLinks = true) => {
-        const valid =
-            !this.validateEmptyValues && !(name in parent) ? true : await this.validateOnChange(name, parent, path);
 
-        const fullPath = [...path, name];
+        const valid =
+            !this.validateEmptyValues && !(name in parent) ? true : await this.validateOnChange(name, parent, [...this.#base ?? [], ...path]);
+
+        const fullPath = [...path, name]; // Use basePath to augment the validation
+        const externalPath = [...this.#base, name]
+
         const isRequired = this.#isRequired(fullPath);
         let warnings = Array.isArray(valid)
             ? valid.filter((info) => info.type === "warning" && (!isRequired || !info.missing))
@@ -688,19 +696,19 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
             ? valid?.filter((info) => info.type === "error" || (isRequired && info.missing))
             : [];
 
-        const hasLinks = this.#getLink(fullPath);
+        const hasLinks = this.#getLink(externalPath);
         if (hasLinks) {
             if (checkLinks) {
-                const isLinkResolved = await this.#isLinkResolved(fullPath);
-                if (!isLinkResolved) {
+                if (!await this.#isLinkResolved(externalPath)) {
                     errors.push(...warnings); // Move warnings to errors if the element is linked
                     warnings = [];
 
                     // Clear old errors and warnings on linked properties
                     this.#applyToLinkedProperties((path) => {
-                        this.#clearMessages(path, "errors");
-                        this.#clearMessages(path, "warnings");
-                    }, fullPath);
+                        const internalPath = path.slice((this.#base ?? []).length)
+                        this.#clearMessages(internalPath, "errors");
+                        this.#clearMessages(internalPath, "warnings");
+                    }, externalPath);
                 }
             }
         } else {
@@ -730,7 +738,7 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
         ) {
             element.classList.remove("invalid");
 
-            const linkEl = this.#getLinkElement(fullPath);
+            const linkEl = this.#getLinkElement(externalPath);
             if (linkEl) linkEl.classList.remove("required", "conditional");
 
             await this.#applyToLinkedProperties((path, element) => {
@@ -744,7 +752,7 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
             // Add new invalid classes and errors
             element.classList.add("invalid");
 
-            const linkEl = this.#getLinkElement(fullPath);
+            const linkEl = this.#getLinkElement(externalPath);
             if (linkEl) linkEl.classList.add("required", "conditional");
 
             // Only add the conditional class for linked elements
@@ -771,7 +779,10 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
         if (renderable.length === 0) return html`<p>No properties to render</p>`;
 
         let renderableWithLinks = renderable.reduce((acc, [name, info]) => {
-            const link = this.#getLink([...path, name]);
+
+            const externalPath = [...this.#base, ...path, name]
+            const link = this.#getLink(externalPath); // Use the base path to find a link
+
             if (link) {
                 if (!acc.find(([_, info]) => info === link)) {
                     const entry = [link.name, link];
@@ -828,7 +839,7 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
             // Render linked properties
             if (entry[isLink]) {
                 const linkedProperties = info.properties.map((path) => {
-                    const pathCopy = [...path];
+                    const pathCopy = [...path].slice((this.#base ?? []).length);
                     const name = pathCopy.pop();
                     return this.#renderInteractiveElement(name, schema.properties[name], results, required, pathCopy);
                 });
@@ -853,6 +864,8 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
                     identifier: this.identifier,
                     schema: info,
                     results: results[name],
+                    globals: this.globals?.[name],
+
                     required: required[name], // Scoped to the sub-schema
                     dialogOptions: this.dialogOptions,
                     dialogType: this.dialogType,
@@ -956,8 +969,10 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
 
         const schema = this.schema ?? {};
 
+        this.resolved = merge(undefined, this.results, {}) // Track resolved values as a copy of the user-specified results
+
         // Register default properties
-        this.#registerDefaultProperties(schema.properties, this.results);
+        resolveProperties(schema.properties, this.resolved, this.globals);
 
         // // Delete extraneous results
         // this.#deleteExtraneousResults(this.results, this.schema);
@@ -967,7 +982,7 @@ ${info.default ? JSON.stringify(info.default, null, 2) : "No default value"}</pr
         return html`
             <div>
                 ${false ? html`<h2>${schema.title}</h2>` : ""} ${false ? html`<p>${schema.description}</p>` : ""}
-                ${this.#render(schema, this.results, this.#requirements, this.#base)}
+                ${this.#render(schema, this.results, this.#requirements)}
             </div>
         `;
     }

--- a/src/renderer/src/stories/Main.js
+++ b/src/renderer/src/stories/Main.js
@@ -123,12 +123,14 @@ export class Main extends LitElement {
         const capsuleEl = capsules ? new GuidedCapsules(capsules) : "";
         const footerEl = footer ? new GuidedFooter(footer) : html`<div></div>`; // Render for grid
 
-        const title = page.info?.title;
+        const title = header?.title ?? page.info?.title;
 
-        let customHeaderContent = header?.content;
-        if (typeof customHeaderContent === "function") customHeaderContent = customHeaderContent(); // Generate custom header content if required
 
-        const showHeader = customHeaderContent || title;
+        let subtitle = header?.subtitle;
+        if (typeof subtitle === "function") subtitle = subtitle(); // Generate custom header content if required
+
+        let controls = header?.controls
+        if (typeof controls === "function") controls = controls(); // Generate custom header content if required
 
         return html`
             ${headerEl}
@@ -137,13 +139,16 @@ export class Main extends LitElement {
                 : html`<div style="height: 25px;"></div>`}
             <main id="content" class="js-content" style="overflow: hidden; display: flex;">
                 <section class="section js-section u-category-windows">
-                    ${showHeader
-                        ? html`<div>
-                              ${customHeaderContent ||
-                              html`<h1 class="title" style="margin: 0; padding: 0;">${title}</h1>`}
-                              <hr />
-                          </div>`
-                        : ""}
+                    ${title ? html`<div><div style="display: flex; flex: 1 1 0px; justify-content: space-between; align-items: end;">
+                        <div style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
+                            <h1 class="title" style="margin: 0; padding: 0;">${title}</h1>
+                            <small style="color: gray;">${subtitle}</small>
+                        </div>
+                        <div style="padding-left: 25px">
+                        ${controls}
+                        </div>
+                    </div><hr /></div>` : ''}
+
                     <div style="height: 10px;"></div>
                     ${page}
                 </section>

--- a/src/renderer/src/stories/Main.js
+++ b/src/renderer/src/stories/Main.js
@@ -108,13 +108,12 @@ export class Main extends LitElement {
                         };
                 }
 
-                if (header === true || !("header" in page) || !('sections' in page.header)) {
+                if (header === true || !("header" in page) || !("sections" in page.header)) {
                     const sectionNames = Object.keys(sections);
 
-                    header = page.header && typeof page.header === 'object' ? page.header : {}
-                    header.sections = sectionNames
-                    header.selected = sectionNames.indexOf(info.section)
-
+                    header = page.header && typeof page.header === "object" ? page.header : {};
+                    header.sections = sectionNames;
+                    header.selected = sectionNames.indexOf(info.section);
                 }
             }
         }
@@ -126,10 +125,10 @@ export class Main extends LitElement {
 
         const title = page.info?.title;
 
-        let customHeaderContent = header?.content
-        if (typeof customHeaderContent === 'function') customHeaderContent = customHeaderContent() // Generate custom header content if required
+        let customHeaderContent = header?.content;
+        if (typeof customHeaderContent === "function") customHeaderContent = customHeaderContent(); // Generate custom header content if required
 
-        const showHeader = customHeaderContent || title
+        const showHeader = customHeaderContent || title;
 
         return html`
             ${headerEl}
@@ -140,8 +139,9 @@ export class Main extends LitElement {
                 <section class="section js-section u-category-windows">
                     ${showHeader
                         ? html`<div>
-                                ${customHeaderContent || html`<h1 class="title" style="margin: 0; padding: 0;">${title}</h1>`}
-                                <hr />
+                              ${customHeaderContent ||
+                              html`<h1 class="title" style="margin: 0; padding: 0;">${title}</h1>`}
+                              <hr />
                           </div>`
                         : ""}
                     <div style="height: 10px;"></div>

--- a/src/renderer/src/stories/pages/FormPage.js
+++ b/src/renderer/src/stories/pages/FormPage.js
@@ -48,8 +48,8 @@ export class GuidedFormPage extends Page {
 
     footer = {
         onNext: async () => {
+            this.save()
             await this.form.validate();
-
             this.onTransition(1);
         },
     };

--- a/src/renderer/src/stories/pages/Page.js
+++ b/src/renderer/src/stories/pages/Page.js
@@ -5,6 +5,7 @@ import { dismissNotification, notify } from "../../dependencies/globals.js";
 import { merge, randomizeElements, mapSessions } from "./utils.js";
 
 import { ProgressBar } from "../ProgressBar";
+import { resolveResults } from "./guided-mode/data/utils.js";
 
 export class Page extends LitElement {
     // static get styles() {
@@ -119,13 +120,20 @@ export class Page extends LitElement {
 
             const { conversion_output_folder, stub_output_folder, name } = this.info.globalState.project;
 
+
+            // Resolve the correct session info from all of the metadata for this conversion
+            const sessionInfo = {
+                ...this.info.globalState.results[subject][session],
+                metadata: resolveResults(subject, session, this.info.globalState)
+            }
+
             const result = await runConversion(
                 {
                     output_folder: conversionOptions.stub_test ? stub_output_folder : conversion_output_folder,
                     project_name: name,
                     nwbfile_path: file,
                     overwrite: true, // We assume override is true because the native NWB file dialog will not allow the user to select an existing file (unless they approve the overwrite)
-                    ...this.info.globalState.results[subject][session], // source_data and metadata are passed in here
+                    ...sessionInfo, // source_data and metadata are passed in here
                     ...conversionOptions, // Any additional conversion options override the defaults
 
                     interfaces: this.info.globalState.interfaces,

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -26,10 +26,10 @@ export class GuidedMetadataPage extends ManagedPage {
 
             // Preview a single random conversion
             delete this.info.globalState.preview; // Clear the preview results
-            const [ result ] = await this.runConversions({ stub_test: true }, 1, {
+            const [result] = await this.runConversions({ stub_test: true }, 1, {
                 title: "Testing conversion on a random session",
             });
-            
+
             this.info.globalState.preview = result; // Save the preview results
 
             this.onTransition(1);
@@ -164,11 +164,11 @@ export class GuidedMetadataPage extends ManagedPage {
                             onClose: () => modal.remove(),
                         });
 
-                        const container = document.createElement('div')
-                        container.style.padding = '0px 25px'
-                        container.append(new UnsafeComponent(html))
+                        const container = document.createElement("div");
+                        container.style.padding = "0px 25px";
+                        container.append(new UnsafeComponent(html));
 
-                        modal.append(container)
+                        modal.append(container);
                         document.body.append(modal);
                     },
                 },

--- a/src/renderer/src/stories/pages/guided-mode/data/utils.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/utils.js
@@ -14,6 +14,49 @@ export function populateWithProjectMetadata(info, globalState) {
     return info;
 }
 
+export function resolveGlobalOverrides(subject, globalState) {
+
+    const subjectMetadataCopy = { ...globalState.subjects[subject] };
+    delete subjectMetadataCopy.sessions; // Remove extra key from metadata
+
+    const overrides = merge(undefined, globalState.project, {}); // Copy project-wide metadata
+    merge("Subject", subjectMetadataCopy, overrides);
+    
+    return overrides
+}
+
+export function resolveProperties(properties = {}, target, globals) {
+
+    if ('properties' in properties && 'type' in properties) properties = properties.properties // Correct for when a schema is passed instead
+    
+    for (let name in properties) {
+        const info = properties[name];
+        const props = info.properties;
+
+        if (!(name in target)) {
+            if (props) target[name] = {}; // Regisiter new interfaces in results
+
+            // Apply global or default value if empty
+            if (name in globals) target[name] = globals[name];
+            else if (info.default) target[name] = info.default;
+        }
+
+        resolveProperties(props, target[name], globals[name])
+    }
+
+    return target
+}
+
+// Explicitly resolve the results for a particular session (from both GUIDE-defined globals and the NWB Schema)
+export function resolveResults(subject, session, globalState){
+    const overrides = resolveGlobalOverrides(subject, globalState) // Unique per-subject (but not sessions)
+    const metadata = globalState.results[subject][session].metadata
+    const results = merge(undefined, metadata, {}) // Copy the metadata results from the form
+    const schema = globalState.schema.metadata[subject][session];
+    resolveProperties(schema, results, overrides) 
+    return results
+}
+
 export function createResults({ subject, info }, globalState) {
     const results = populateWithProjectMetadata(info.metadata, globalState);
     const metadataCopy = { ...globalState.subjects[subject] };

--- a/src/renderer/src/stories/pages/guided-mode/data/utils.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/utils.js
@@ -25,7 +25,7 @@ export function resolveGlobalOverrides(subject, globalState) {
     return overrides
 }
 
-export function resolveProperties(properties = {}, target, globals) {
+export function resolveProperties(properties = {}, target, globals = {}) {
 
     if ('properties' in properties && 'type' in properties) properties = properties.properties // Correct for when a schema is passed instead
     

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -15,9 +15,8 @@ export class GuidedStubPreviewPage extends Page {
 
     header = {
         content: () => {
+            const info = this.info.globalState.preview;
 
-            const info = this.info.globalState.preview
-            
             return html`
                 <div style="display: flex; flex: 1 1 0px; justify-content: space-between; align-items: end;">
                     <div style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
@@ -25,15 +24,14 @@ export class GuidedStubPreviewPage extends Page {
                         <small style="color: gray;">${info.file}</small>
                     </div>
                     <div style="padding-left: 25px">
-                        <nwb-button
-                            size="small"
-                            @click=${() => shell ? shell.showItemInFolder(info.file) : ''}
-                        >${unsafeSVG(folderOpenSVG)}</nwb-button>
+                        <nwb-button size="small" @click=${() => (shell ? shell.showItemInFolder(info.file) : "")}
+                            >${unsafeSVG(folderOpenSVG)}</nwb-button
+                        >
                     </div>
                 </div>
-            `
-        }
-    }
+            `;
+        },
+    };
 
     footer = {
         next: "Run Conversion",
@@ -49,8 +47,7 @@ export class GuidedStubPreviewPage extends Page {
     };
 
     render() {
-
-        const info = this.info.globalState.preview
+        const info = this.info.globalState.preview;
 
         return html`
             <div>

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -14,23 +14,10 @@ export class GuidedStubPreviewPage extends Page {
     }
 
     header = {
-        content: () => {
-            const info = this.info.globalState.preview;
-
-            return html`
-                <div style="display: flex; flex: 1 1 0px; justify-content: space-between; align-items: end;">
-                    <div style="white-space: nowrap; overflow: hidden; text-overflow: ellipsis;">
-                        <h1 class="title" style="margin: 0; padding: 0;">Conversion Preview</h1>
-                        <small style="color: gray;">${info.file}</small>
-                    </div>
-                    <div style="padding-left: 25px">
-                        <nwb-button size="small" @click=${() => (shell ? shell.showItemInFolder(info.file) : "")}
-                            >${unsafeSVG(folderOpenSVG)}</nwb-button
-                        >
-                    </div>
-                </div>
-            `;
-        },
+        subtitle: () => this.info.globalState.preview.file,
+        controls: () => html`<nwb-button size="small" @click=${() => (shell ? shell.showItemInFolder(this.info.globalState.preview.file) : "")}
+            >${unsafeSVG(folderOpenSVG)}</nwb-button
+        >`
     };
 
     footer = {

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedSubjects.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedSubjects.js
@@ -2,14 +2,17 @@ import { html } from "lit";
 import { Page } from "../../Page.js";
 import subjectSchema from "../../../../../../../schemas/subject.schema";
 import { validateOnChange } from "../../../../validation/index.js";
-import { SimpleTable } from "../../../SimpleTable.js";
 import { Table } from "../../../Table.js";
 
-import { convertSubjectsToResults } from "./utils";
+import { updateResultsFromSubjects } from "./utils";
 
 export class GuidedSubjectsPage extends Page {
     constructor(...args) {
         super(...args);
+    }
+
+    header = {
+        subtitle: "Cross-session metadata applied to the final file metadata"
     }
 
     footer = {
@@ -35,7 +38,8 @@ export class GuidedSubjectsPage extends Page {
                 return acc;
             }, {});
 
-            convertSubjectsToResults(results, subjects, sourceDataObject); // NOTE: This directly mutates the results object
+            // Modify the results object to track new subjects / sessions
+            updateResultsFromSubjects(results, subjects, sourceDataObject); // NOTE: This directly mutates the results object
 
             this.onTransition(1);
         },

--- a/src/renderer/src/stories/pages/guided-mode/setup/utils.ts
+++ b/src/renderer/src/stories/pages/guided-mode/setup/utils.ts
@@ -1,5 +1,5 @@
 
-export const convertSubjectsToResults = (results: any, subjects: any, sourceDataObject = {}) => {
+export const updateResultsFromSubjects = (results: any, subjects: any, sourceDataObject = {}) => {
 
     const toRemove = Object.keys(results).filter((sub) => !Object.keys(subjects).includes(sub));
     for (let sub of toRemove) delete results[sub]; // Delete extra subjects from results

--- a/src/renderer/src/stories/pages/utils.js
+++ b/src/renderer/src/stories/pages/utils.js
@@ -31,7 +31,7 @@ export function merge(path, toMerge = {}, target = this.info.globalState) {
     if (key in target) {
         for (const [k, v] of Object.entries(toMerge)) {
             if (typeof v === "object" && !Array.isArray(v)) {
-                if (!target[key][k]) target[key][k] = v;
+                if (!target[key][k]) target[key][k] = {...v}; // Copy objects
                 else this.merge(`${k}`, v, target[key]);
             } else target[key][k] = v;
         }

--- a/tests/metadata.test.ts
+++ b/tests/metadata.test.ts
@@ -8,7 +8,7 @@ import { createMockGlobalState } from './utils'
 
 import { Validator, validate } from 'jsonschema'
 import { textToArray } from '../src/renderer/src/stories/forms/utils'
-import { convertSubjectsToResults } from '../src/renderer/src/stories/pages/guided-mode/setup/utils'
+import { updateResultsFromSubjects } from '../src/renderer/src/stories/pages/guided-mode/setup/utils'
 import { JSONSchemaForm } from '../src/renderer/src/stories/JSONSchemaForm'
 
 import { validateOnChange } from "../src/renderer/src/validation/index.js";
@@ -44,7 +44,7 @@ test('removing all existing sessions will maintain the related subject entry on 
 
     const subjects = { subject: { sessions: ['renamed'] } }
 
-    convertSubjectsToResults(results, subjects)
+    updateResultsFromSubjects(results, subjects)
     expect(Object.keys(results)).toEqual(Object.keys(copy))
 })
 


### PR DESCRIPTION
This PR improves the data representation for the NWB GUIDE File Metadata by implementing a proper cascade of Subject Global Metadata —> Subject table metadata —> NWB File Subject Metadata for the final results sent to `neuroconv`. 

With these changes, each project form result is kept separate until aggregated to send to the server. As such, we can now distinguish between auto-filled form values (i.e. values from higher in the cascade) and user-defined values.

> **Note:** This allows users to define, for instance, a global `genotype` property, overwrite this for a specific session, then change that global property without negating the previous change. 

This also allows us to dismiss problems related to reconciliation noted in #252, as data _should not_ flow from further down in the cascade. As such, we should make UI changes that limit our ability to edit a common bit of data (e.g. `session_id`) managed by an upstream form (e.g. the Subject table) in dependent forms (e.g. the NWB File metadata form). 