### PR TITLE
Properly update instance manager status

### DIFF
--- a/src/renderer/src/stories/InstanceManager.js
+++ b/src/renderer/src/stories/InstanceManager.js
@@ -3,6 +3,7 @@ import "./Button";
 import { notify } from "../dependencies/globals";
 import { Accordion } from "./Accordion";
 import { InstanceListItem } from "./instances/item";
+import { checkStatus } from "../validation";
 
 export class InstanceManager extends LitElement {
     static get styles() {
@@ -137,14 +138,18 @@ export class InstanceManager extends LitElement {
 
     updateState = (id, state) => {
         const item = this.#items.find((i) => i.id === id);
+
         item.status = state;
 
         // Carry the status upwards
         const path = id.split("/");
+
+        let target = this.instances
         for (let i = 0; i < path.length; i++) {
             const id = path.slice(0, i + 1).join("/");
             const accordion = this.#accordions[id];
-            if (accordion) accordion.setSectionStatus(id, state);
+            target = target[path[i]] // Progressively check the deeper nested instances
+            if (accordion) accordion.setSectionStatus(id, checkStatus(false, false, [...Object.values(target)]));
         }
     };
 

--- a/src/renderer/src/stories/InstanceManager.js
+++ b/src/renderer/src/stories/InstanceManager.js
@@ -144,11 +144,11 @@ export class InstanceManager extends LitElement {
         // Carry the status upwards
         const path = id.split("/");
 
-        let target = this.instances
+        let target = this.instances;
         for (let i = 0; i < path.length; i++) {
             const id = path.slice(0, i + 1).join("/");
             const accordion = this.#accordions[id];
-            target = target[path[i]] // Progressively check the deeper nested instances
+            target = target[path[i]]; // Progressively check the deeper nested instances
             if (accordion) accordion.setSectionStatus(id, checkStatus(false, false, [...Object.values(target)]));
         }
     };

--- a/src/renderer/src/validation/index.js
+++ b/src/renderer/src/validation/index.js
@@ -89,7 +89,8 @@ export function checkStatus(warnings, errors, items = []) {
     if (nestedStatus.includes("error")) newStatus = "error";
     else if (errors) newStatus = "error";
     else if (nestedStatus.includes("warning")) newStatus = "warning";
-    else if (warnings) newStatus = "warning"
-    if (this && this.onStatusChange && 'status' in this && newStatus !== this.status) this.onStatusChange((this.status = newStatus)); // Automatically run callbacks if supported by the context
-    return newStatus
+    else if (warnings) newStatus = "warning";
+    if (this && this.onStatusChange && "status" in this && newStatus !== this.status)
+        this.onStatusChange((this.status = newStatus)); // Automatically run callbacks if supported by the context
+    return newStatus;
 }

--- a/src/renderer/src/validation/index.js
+++ b/src/renderer/src/validation/index.js
@@ -89,7 +89,7 @@ export function checkStatus(warnings, errors, items = []) {
     if (nestedStatus.includes("error")) newStatus = "error";
     else if (errors) newStatus = "error";
     else if (nestedStatus.includes("warning")) newStatus = "warning";
-    else if (warnings) newStatus = "warning";
-
-    if (newStatus !== this.status) this.onStatusChange((this.status = newStatus));
+    else if (warnings) newStatus = "warning"
+    if (this && this.onStatusChange && 'status' in this && newStatus !== this.status) this.onStatusChange((this.status = newStatus)); // Automatically run callbacks if supported by the context
+    return newStatus
 }


### PR DESCRIPTION
This PR fixes the way that the instance manager status is updated. 

Previously the status of multi-session instance Accordions would change if a single session's status changed. Now the collective status of the instances is reconciled properly.