### PR TITLE
Make chromatic CI manual dispatch only

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,6 +1,6 @@
 name: "Chromatic Publish"
 
-on: pull_request
+on: workflow_dispatch
 
 jobs:
   test:


### PR DESCRIPTION
To partially combat overusage of Chromatic during a billing period when there are tons of PRs that trigger an update every time they need their branch updated, I propose to make it required for merge but only triggerable manually, which the reviewer will do during final review (or perhaps multiple times if revisions are requested)