### PR TITLE
Improve Error Messages (GuidedSourceData)

### DIFF
--- a/pyflask/apis/apiNeuroConv.py
+++ b/pyflask/apis/apiNeuroConv.py
@@ -1,5 +1,6 @@
 from flask_restx import Namespace, Resource, reqparse
 from flask import Response
+import traceback
 
 from namespaces import get_namespace, NamespaceEnum
 from manageNeuroconv import (
@@ -21,6 +22,10 @@ api = get_namespace(NamespaceEnum.NEUROCONV)
 
 parser = reqparse.RequestParser()
 parser.add_argument("interfaces", type=str, action="split", help="Interfaces cannot be converted")
+
+@api.errorhandler(Exception)
+def exception_handler(error):
+    return { "message": ''.join(traceback.format_exception(type(error), error, error.__traceback__))}
 
 
 @api.route("/")
@@ -61,12 +66,12 @@ class Locate(Resource):
 class Metadata(Resource):
     @api.doc(responses={200: "Success", 400: "Bad Request", 500: "Internal server error"})
     def post(self):
-        try:
+        # try:
             return get_metadata_schema(api.payload.get("source_data"), api.payload.get("interfaces"))
 
-        except Exception as e:
-            if notBadRequestException(e):
-                api.abort(500, str(e))
+        # except Exception as e:
+        #     if notBadRequestException(e):
+        #         api.abort(500, str(e))
 
 
 @api.route("/convert")

--- a/pyflask/apis/apiNeuroConv.py
+++ b/pyflask/apis/apiNeuroConv.py
@@ -25,7 +25,9 @@ parser.add_argument("interfaces", type=str, action="split", help="Interfaces can
 
 @api.errorhandler(Exception)
 def exception_handler(error):
-    return { "message": ''.join(traceback.format_exception(type(error), error, error.__traceback__))}
+    exceptiondata = traceback.format_exception(type(error), error, error.__traceback__, limit=1)
+    exceptionarray = exceptiondata[-2:]
+    return { "message": exceptiondata} # ''.join(exceptionarray)}
 
 
 @api.route("/")

--- a/pyflask/apis/apiNeuroConv.py
+++ b/pyflask/apis/apiNeuroConv.py
@@ -25,9 +25,8 @@ parser.add_argument("interfaces", type=str, action="split", help="Interfaces can
 
 @api.errorhandler(Exception)
 def exception_handler(error):
-    exceptiondata = traceback.format_exception(type(error), error, error.__traceback__, limit=1)
-    exceptionarray = exceptiondata[-2:]
-    return { "message": exceptiondata} # ''.join(exceptionarray)}
+    exceptiondata = traceback.format_exception(type(error), error, error.__traceback__)
+    return { "message": exceptiondata[-1], "traceback": ''.join(exceptiondata) }
 
 
 @api.route("/")

--- a/pyflask/apis/apiNeuroConv.py
+++ b/pyflask/apis/apiNeuroConv.py
@@ -23,10 +23,11 @@ api = get_namespace(NamespaceEnum.NEUROCONV)
 parser = reqparse.RequestParser()
 parser.add_argument("interfaces", type=str, action="split", help="Interfaces cannot be converted")
 
+
 @api.errorhandler(Exception)
 def exception_handler(error):
     exceptiondata = traceback.format_exception(type(error), error, error.__traceback__)
-    return { "message": exceptiondata[-1], "traceback": ''.join(exceptiondata) }
+    return {"message": exceptiondata[-1], "traceback": "".join(exceptiondata)}
 
 
 @api.route("/")
@@ -68,11 +69,11 @@ class Metadata(Resource):
     @api.doc(responses={200: "Success", 400: "Bad Request", 500: "Internal server error"})
     def post(self):
         # try:
-            return get_metadata_schema(api.payload.get("source_data"), api.payload.get("interfaces"))
+        return get_metadata_schema(api.payload.get("source_data"), api.payload.get("interfaces"))
 
-        # except Exception as e:
-        #     if notBadRequestException(e):
-        #         api.abort(500, str(e))
+    # except Exception as e:
+    #     if notBadRequestException(e):
+    #         api.abort(500, str(e))
 
 
 @api.route("/convert")

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -67,7 +67,14 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (isStorybook) return;
 
                     if (result.message) {
-                        const [ type, text = `<small><pre>${result.traceback.trim().split('\n').slice(-2)[0].trim()}</pre></small>` ] = result.message.split(':')
+                        const [
+                            type,
+                            text = `<small><pre>${result.traceback
+                                .trim()
+                                .split("\n")
+                                .slice(-2)[0]
+                                .trim()}</pre></small>`,
+                        ] = result.message.split(":");
                         const message = `<h4 style="margin: 0;">Request Failed</h4><small>${type}</small><p>${text}</p>`;
                         this.notify(message, "error");
                         throw result;

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -67,7 +67,7 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (isStorybook) return;
 
                     if (result.message) {
-                        const message = `<p>Failed to get metadata with current source data. Please try again.</p>`;
+                        const message = `<b>Request Failed:</b> ${result.message}`;
                         this.notify(message, "error");
                         throw result;
                     }

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -67,7 +67,8 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (isStorybook) return;
 
                     if (result.message) {
-                        const message = `<b>Request Failed:</b> ${result.message}`;
+                        const [ type, text = `<small><pre>${result.traceback.trim().split('\n').slice(-2)[0].trim()}</pre></small>` ] = result.message.split(':')
+                        const message = `<h4 style="margin: 0;">Request Failed</h4><small>${type}</small><p>${text}</p>`;
                         this.notify(message, "error");
                         throw result;
                     }

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -67,7 +67,7 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (isStorybook) return;
 
                     if (result.message) {
-                        const message = "Failed to get metadata with current source data. Please try again.";
+                        const message = `<p>Failed to get metadata with current source data. Please try again.</p>`;
                         this.notify(message, "error");
                         throw result;
                     }


### PR DESCRIPTION
This PR improves the error messages received when requesting the metadata schema (during the transition from the GuidedSourceData page).

If no message is provided with the error, the code that threw the error is printed:
![Screenshot 2023-08-09 at 9 28 34 AM](https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/e23ede4a-e73d-474e-abf7-46e30089b27d)

Otherwise, the message is provided:
![Screenshot 2023-08-09 at 9 29 22 AM](https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/6e9b510d-614e-45b1-96c7-aee9bb4240fd)
