### PR TITLE
Replace HTML representation of the NWB file with Neurosift

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -236,7 +236,6 @@ def validate_metadata(metadata: dict, check_function_name: str) -> dict:
 
 def convert_to_nwb(info: dict) -> str:
     """Function used to convert the source data to NWB format using the specified metadata."""
-    from pynwb import NWBHDF5IO
 
     nwbfile_path = Path(info["nwbfile_path"])
     custom_output_directory = info.get("output_folder")
@@ -311,11 +310,6 @@ def convert_to_nwb(info: dict) -> str:
         conversion_options=options,
     )
 
-    io = NWBHDF5IO(resolved_output_path, mode="r")
-    file = io.read()
-    html = file._repr_html_()
-    io.close()
-
     # Create a symlink between the fake adata and custom data
     if not run_stub_test and not resolved_output_directory == default_output_directory:
         if default_output_directory.exists():
@@ -335,7 +329,7 @@ def convert_to_nwb(info: dict) -> str:
         if not default_output_directory.exists():
             os.symlink(resolved_output_directory, default_output_directory)
 
-    return dict(html=html, file=str(resolved_output_path))
+    return str(resolved_output_path)
 
 
 def upload_to_dandi(

--- a/src/renderer/src/stories/Neurosift.js
+++ b/src/renderer/src/stories/Neurosift.js
@@ -1,32 +1,30 @@
-import { LitElement, css, html } from "lit"
-import { baseUrl } from "../globals"
+import { LitElement, css, html } from "lit";
+import { baseUrl } from "../globals";
 
 export function getURLFromFilePath(file, projectName) {
-    const regexp = new RegExp(`.+(${projectName}.+)`)
-    return `${baseUrl}/stubs/${file.match(regexp)[1]}`
+    const regexp = new RegExp(`.+(${projectName}.+)`);
+    return `${baseUrl}/stubs/${file.match(regexp)[1]}`;
 }
 
 export class Neurosift extends LitElement {
-
     static get styles() {
         return css`
-            iframe { 
-                width: 100%; 
+            iframe {
+                width: 100%;
                 height: 100%;
                 border: 0;
             }
-        `
+        `;
     }
 
     constructor({ url }) {
-        super()
-        this.url = url
+        super();
+        this.url = url;
     }
 
     render() {
-        return html`<iframe src="https://flatironinstitute.github.io/neurosift/?p=/nwb&url=${this.url}"></iframe>`
+        return html`<iframe src="https://flatironinstitute.github.io/neurosift/?p=/nwb&url=${this.url}"></iframe>`;
     }
 }
 
-customElements.get("neurosift-iframe") ||
-    customElements.define("neurosift-iframe", Neurosift);
+customElements.get("neurosift-iframe") || customElements.define("neurosift-iframe", Neurosift);

--- a/src/renderer/src/stories/Neurosift.js
+++ b/src/renderer/src/stories/Neurosift.js
@@ -1,0 +1,32 @@
+import { LitElement, css, html } from "lit"
+import { baseUrl } from "../globals"
+
+export function getURLFromFilePath(file, projectName) {
+    const regexp = new RegExp(`.+(${projectName}.+)`)
+    return `${baseUrl}/stubs/${file.match(regexp)[1]}`
+}
+
+export class Neurosift extends LitElement {
+
+    static get styles() {
+        return css`
+            iframe { 
+                width: 100%; 
+                height: 100%;
+                border: 0;
+            }
+        `
+    }
+
+    constructor({ url }) {
+        super()
+        this.url = url
+    }
+
+    render() {
+        return html`<iframe src="https://flatironinstitute.github.io/neurosift/?p=/nwb&url=${this.url}"></iframe>`
+    }
+}
+
+customElements.get("neurosift-iframe") ||
+    customElements.define("neurosift-iframe", Neurosift);

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -10,6 +10,7 @@ import Swal from "sweetalert2";
 import { SimpleTable } from "../../../SimpleTable.js";
 import { onThrow } from "../../../../errors";
 import { UnsafeComponent } from "../../Unsafe.js";
+import { Neurosift, getURLFromFilePath } from "../../../Neurosift.js";
 
 export class GuidedMetadataPage extends ManagedPage {
     constructor(...args) {
@@ -158,11 +159,14 @@ export class GuidedMetadataPage extends ManagedPage {
                     name: "Preview",
                     primary: true,
                     onClick: async (key, el) => {
+                        
+                        const { project } = this.info.globalState
+
                         let [subject, session] = key.split("/");
                         if (subject.startsWith("sub-")) subject = subject.slice(4);
                         if (session.startsWith("ses-")) session = session.slice(4);
 
-                        const [{ file, html }] = await this.runConversions(
+                        const [file] = await this.runConversions(
                             { stub_test: true },
                             [{ subject, session }],
                             { title: "Running conversion preview" }
@@ -179,11 +183,7 @@ export class GuidedMetadataPage extends ManagedPage {
                             height: "100%",
                         });
 
-                        const container = document.createElement("div");
-                        container.style.padding = "0px 25px";
-                        container.append(new UnsafeComponent(html));
-
-                        modal.append(container);
+                        modal.append(new Neurosift({ url: getURLFromFilePath(file, project.name)}));
                         document.body.append(modal);
                     },
                 },

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -159,18 +159,15 @@ export class GuidedMetadataPage extends ManagedPage {
                     name: "Preview",
                     primary: true,
                     onClick: async (key, el) => {
-                        
-                        const { project } = this.info.globalState
+                        const { project } = this.info.globalState;
 
                         let [subject, session] = key.split("/");
                         if (subject.startsWith("sub-")) subject = subject.slice(4);
                         if (session.startsWith("ses-")) session = session.slice(4);
 
-                        const [file] = await this.runConversions(
-                            { stub_test: true },
-                            [{ subject, session }],
-                            { title: "Running conversion preview" }
-                        ).catch((e) => {
+                        const [file] = await this.runConversions({ stub_test: true }, [{ subject, session }], {
+                            title: "Running conversion preview",
+                        }).catch((e) => {
                             this.notify(e.message, "error");
                             throw e;
                         });
@@ -183,7 +180,7 @@ export class GuidedMetadataPage extends ManagedPage {
                             height: "100%",
                         });
 
-                        modal.append(new Neurosift({ url: getURLFromFilePath(file, project.name)}));
+                        modal.append(new Neurosift({ url: getURLFromFilePath(file, project.name) }));
                         document.body.append(modal);
                     },
                 },

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
@@ -32,7 +32,7 @@ export class GuidedStructurePage extends Page {
     });
 
     list = new List({
-        emptyMessage: 'No interfaces selected'
+        emptyMessage: "No interfaces selected",
     });
 
     addButton = new Button();
@@ -54,7 +54,7 @@ export class GuidedStructurePage extends Page {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify(interfaces),
-            }).then((res) => res.json())
+            }).then((res) => res.json());
 
             let schemas = this.info.globalState.schema;
             if (!schemas) schemas = this.info.globalState.schema = {};

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -1,11 +1,11 @@
 import { html } from "lit";
 import { Page } from "../../Page.js";
 
-import { UnsafeComponent } from "../../Unsafe.js";
 import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import folderOpenSVG from "../../../assets/folder_open.svg?raw";
 
 import { electron } from "../../../../electron/index.js";
+import { Neurosift, getURLFromFilePath } from "../../../Neurosift.js";
 const { shell } = electron;
 
 export class GuidedStubPreviewPage extends Page {
@@ -14,11 +14,11 @@ export class GuidedStubPreviewPage extends Page {
     }
 
     header = {
-        subtitle: () => this.info.globalState.preview.file,
+        subtitle: () => this.info.globalState.preview,
         controls: () =>
             html`<nwb-button
                 size="small"
-                @click=${() => (shell ? shell.showItemInFolder(this.info.globalState.preview.file) : "")}
+                @click=${() => (shell ? shell.showItemInFolder(this.info.globalState.preview) : "")}
                 >${unsafeSVG(folderOpenSVG)}</nwb-button
             >`,
     };
@@ -37,15 +37,9 @@ export class GuidedStubPreviewPage extends Page {
     };
 
     render() {
-        const info = this.info.globalState.preview;
-
-        return html`
-            <div>
-                ${info
-                    ? new UnsafeComponent(info.html)
-                    : html`<p style="text-align: center;">Your conversion preview failed. Please try again.</p>`}
-            </div>
-        `;
+        const { project, preview } = this.info.globalState;
+        
+        return preview ? new Neurosift({ url: getURLFromFilePath(preview, project.name)}) : html`<p style="text-align: center;">Your conversion preview failed. Please try again.</p>`;
     }
 }
 

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -38,8 +38,10 @@ export class GuidedStubPreviewPage extends Page {
 
     render() {
         const { project, preview } = this.info.globalState;
-        
-        return preview ? new Neurosift({ url: getURLFromFilePath(preview, project.name)}) : html`<p style="text-align: center;">Your conversion preview failed. Please try again.</p>`;
+
+        return preview
+            ? new Neurosift({ url: getURLFromFilePath(preview, project.name) })
+            : html`<p style="text-align: center;">Your conversion preview failed. Please try again.</p>`;
     }
 }
 


### PR DESCRIPTION
This PR uses an iframe to point the Neurosift application to the locally hosted stub file being previewed to provide a comprehensive look at the contents of the file.