### PR TITLE
Allow Restarting Flask Server

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -48,6 +48,7 @@ let globals =  {
   python: {
     status: false,
     sent: false,
+    restart: false,
     latestError: ''
   },
 
@@ -98,7 +99,7 @@ const pythonIsOpen = (force = false) => {
 const pythonIsClosed = (err = globals.python.latestError) => {
 
     onWindowReady(win => {
-      send.call(win, "python.closed", err)
+      send.call(win, globals.python.restart ? "python.restart" : "python.closed", err)
       globals.python.sent = true
     })
 
@@ -120,41 +121,49 @@ const getPackagedPath = () => {
 };
 
 const createPyProc = async () => {
-  let script = getPackagedPath() || path.join(__dirname, PY_FLASK_FOLDER, "app.py");
-  await killAllPreviousProcesses();
 
-  const defaultPort = PORT as number
+  return new Promise(async (resolve, reject) => {
+
+    let script = getPackagedPath() || path.join(__dirname, PY_FLASK_FOLDER, "app.py");
+    await killAllPreviousProcesses();
+
+    const defaultPort = PORT as number
 
 
-  fp(defaultPort, defaultPort + portRange)
-    .then(([freePort]: string[]) => {
-      selectedPort = freePort;
+    fp(defaultPort, defaultPort + portRange)
+      .then(([freePort]: string[]) => {
+        selectedPort = freePort;
 
-      pyflaskProcess = (script.slice(-3) === '.py') ? child_process.spawn("python", [script, freePort], {}) : child_process.spawn(`${script}`, [freePort], {});
+        pyflaskProcess = (script.slice(-3) === '.py') ? child_process.spawn("python", [script, freePort], {}) : child_process.spawn(`${script}`, [freePort], {});
 
-      if (pyflaskProcess != null) {
+        if (pyflaskProcess != null) {
 
-        // Listen for errors from Python process
-        pyflaskProcess.stderr.on("data", (data: string) => {
-          console.error(`${data}`)
-          globals.python.latestError = data.toString()
-        });
+          // Listen for errors from Python process
+          pyflaskProcess.stderr.on("data", (data: string) => {
+            console.error(`${data}`)
+            globals.python.latestError = data.toString()
+          });
 
-        pyflaskProcess.stdout.on('data', (data: string) => {
-          pythonIsOpen();
-          console.log(`${data}`)
-        });
+          pyflaskProcess.stdout.on('data', (data: string) => {
+            const isRestarting = globals.python.restart
+            setTimeout(() => pythonIsOpen(isRestarting), 100); // Wait just a bit to give the server some time to come online
+            console.log(`${data}`)
+            resolve(true)
+          });
 
-        pyflaskProcess.on('close', (code: number) => {
-          console.error(`exit code ${code}`)
-          pythonIsClosed()
-        });
+          pyflaskProcess.on('close', (code: number) => {
+            console.error(`exit code ${code}`)
+            pythonIsClosed()
+            reject()
+          });
 
-      }
+        }
+      })
+      .catch((err: Error) => {
+        console.log(err);
+        reject(err)
+      });
     })
-    .catch((err: Error) => {
-      console.log(err);
-    });
 };
 
 /**
@@ -283,16 +292,15 @@ function initialize() {
     // Listen after first load
     promise.then(() => {
       const chokidar = require('chokidar');
-      let done = true
       chokidar.watch(path.join(__dirname, "../../pyflask"), {
         ignored:  ['**/__pycache__/**']
       }).on('all', async (event: string) => {
-        if (event === 'change' && done) {
-          done = false
+        if (event === 'change' && !globals.python.restart) {
+          globals.python.restart = true
           await exitPyProc();
           setTimeout(async () => {
             await createPyProc();
-            done = true
+            globals.python.restart = false
           }, 1000)
         }
       });

--- a/src/renderer/src/index.ts
+++ b/src/renderer/src/index.ts
@@ -100,6 +100,7 @@ const serverIsLiveStartup = async () => {
   return echoResponse === "server ready" ? true : false;
 };
 
+let openPythonStatusNotyf: undefined | any;
 
 async function pythonServerOpened() {
 
@@ -109,7 +110,9 @@ async function pythonServerOpened() {
 
   // Update server status and throw a notification
   statusBar.items[2].status = true
-  notyf.open({
+
+  if (openPythonStatusNotyf) notyf.dismiss(openPythonStatusNotyf)
+  openPythonStatusNotyf = notyf.open({
     type: "success",
     message: "Backend services are available",
   });
@@ -145,6 +148,14 @@ if (isElectron) {
     ipcRenderer.on("python.open", pythonServerOpened);
 
     ipcRenderer.on("python.closed", (_, message) => pythonServerClosed(message));
+    ipcRenderer.on("python.restart", () => {
+      statusBar.items[2].status = undefined
+      if (openPythonStatusNotyf) notyf.dismiss(openPythonStatusNotyf)
+      openPythonStatusNotyf = notyf.open({
+        type: "warning",
+        message: "Backend services are restarting...",
+      })
+    });
 
     // Check for update and show the pop up box
     ipcRenderer.on("update_available", () => {


### PR DESCRIPTION
This PR accounts for the restart condition when calling the new notification functions for when the Flask server opens and closes.

Without these changes, the GUIDE forces you to restart when the server is restarting