### PR TITLE
Modularize Inspector Preview

### DIFF
--- a/pyflask/apis/neuroconv.py
+++ b/pyflask/apis/neuroconv.py
@@ -21,6 +21,7 @@ neuroconv_api = Namespace("neuroconv", description="Neuroconv neuroconv_api for 
 parser = reqparse.RequestParser()
 parser.add_argument("interfaces", type=str, action="split", help="Interfaces cannot be converted")
 
+
 @neuroconv_api.errorhandler(Exception)
 def exception_handler(error):
     exceptiondata = traceback.format_exception(type(error), error, error.__traceback__)

--- a/pyflask/apis/neuroconv.py
+++ b/pyflask/apis/neuroconv.py
@@ -21,7 +21,6 @@ neuroconv_api = Namespace("neuroconv", description="Neuroconv neuroconv_api for 
 parser = reqparse.RequestParser()
 parser.add_argument("interfaces", type=str, action="split", help="Interfaces cannot be converted")
 
-
 @neuroconv_api.errorhandler(Exception)
 def exception_handler(error):
     exceptiondata = traceback.format_exception(type(error), error, error.__traceback__)
@@ -170,6 +169,8 @@ class InspectNWBFolder(Resource):
                     **neuroconv_api.payload,
                 )
             )
+
+            # messages = organize_messages(messages, levels=["importance", "message"])
 
             return json.loads(json.dumps(messages, cls=InspectorOutputJSONEncoder))
 

--- a/src/renderer/src/pages.js
+++ b/src/renderer/src/pages.js
@@ -14,6 +14,7 @@ import { GuidedUploadPage } from "./stories/pages/guided-mode/options/GuidedUplo
 import { GuidedResultsPage } from "./stories/pages/guided-mode/results/GuidedResults";
 import { Dashboard } from "./stories/Dashboard";
 import { GuidedStubPreviewPage } from "./stories/pages/guided-mode/options/GuidedStubPreview";
+import { GuidedInspectorPage } from "./stories/pages/guided-mode/options/GuidedInspectorPage";
 
 import logo from "../assets/img/logo-guide-draft-transparent-tight.png";
 import { GuidedPathExpansionPage } from "./stories/pages/guided-mode/data/GuidedPathExpansion";
@@ -132,20 +133,27 @@ const pages = {
                 section: sections[1],
             }),
 
-            preview: new GuidedStubPreviewPage({
-                title: "Conversion Preview",
-                label: "Preview conversion",
+            inspect: new GuidedInspectorPage({
+                title: "Inspector Report",
+                label: "Inspect files",
                 section: sections[2],
             }),
+
+            preview: new GuidedStubPreviewPage({
+                title: "Conversion Preview",
+                label: "Preview files",
+                section: sections[2],
+            }),
+
             upload: new GuidedUploadPage({
                 title: "DANDI Upload Options",
-                label: "DANDI upload",
-                section: sections[2],
+                label: "Upload to DANDI",
+                section: sections[3],
             }),
 
             review: new GuidedResultsPage({
                 title: "Conversion Review",
-                label: "Review results",
+                label: "View conversion report",
                 section: sections[3],
             }),
         },

--- a/src/renderer/src/stories/Main.js
+++ b/src/renderer/src/stories/Main.js
@@ -141,7 +141,7 @@ export class Main extends LitElement {
             <main id="content" class="js-content" style="overflow: hidden; display: flex;">
                 <section class="section js-section u-category-windows">
                     ${title
-                        ? html`<div>
+                        ? html`<div style="position: sticky; top: 0; left: 0; background: white; z-index: 1;">
                               <div
                                   style="display: flex; flex: 1 1 0px; justify-content: space-between; align-items: end;"
                               >
@@ -151,12 +151,13 @@ export class Main extends LitElement {
                                   </div>
                                   <div style="padding-left: 25px">${controls}</div>
                               </div>
-                              <hr />
+                              <hr style="margin-bottom: 0;"/>
                           </div>`
                         : ""}
 
-                    <div style="height: 10px;"></div>
-                    ${page}
+                    <div style="padding-top: 10px; height: 100%; width: 100%;">
+                        ${page}
+                    </div>
                 </section>
             </main>
             ${footerEl}

--- a/src/renderer/src/stories/Main.js
+++ b/src/renderer/src/stories/Main.js
@@ -151,13 +151,11 @@ export class Main extends LitElement {
                                   </div>
                                   <div style="padding-left: 25px">${controls}</div>
                               </div>
-                              <hr style="margin-bottom: 0;"/>
+                              <hr style="margin-bottom: 0;" />
                           </div>`
                         : ""}
 
-                    <div style="padding-top: 10px; height: 100%; width: 100%;">
-                        ${page}
-                    </div>
+                    <div style="padding-top: 10px; height: 100%; width: 100%;">${page}</div>
                 </section>
             </main>
             ${footerEl}

--- a/src/renderer/src/stories/pages/globals.js
+++ b/src/renderer/src/stories/pages/globals.js
@@ -1,1 +1,1 @@
-export const sections = ["Project Structure", "Data Review", "Conversion Options", "Conversion Output"];
+export const sections = ["Project Structure", "Data Review", "Conversion Preview", "Final Review"];

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -38,13 +38,16 @@ export class GuidedMetadataPage extends ManagedPage {
             for (let { form } of this.forms) await form.validate(); // Will throw an error in the callback
 
             // Preview a single random conversion
-            delete this.info.globalState.stubs; // Clear the preview results
+            delete this.info.globalState.preview; // Clear the preview results
+
             const stubs = await this.runConversions({ stub_test: true }, undefined, {
                 title: "Running stub conversion on all sessions...",
             });
 
             // Save the preview results
-            this.info.globalState.stubs = stubs;
+            this.info.globalState.preview = {
+                stubs
+            };
 
             this.unsavedUpdates = true;
 
@@ -210,7 +213,7 @@ export class GuidedMetadataPage extends ManagedPage {
 
                         const { project } = this.info.globalState;
 
-                        modal.append(new NWBFilePreview({ project: project.name, files: results }));
+                        modal.append(new NWBFilePreview({ project: project.name, files: results, inspect: true }));
                         document.body.append(modal);
                     },
                 },

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -46,7 +46,7 @@ export class GuidedMetadataPage extends ManagedPage {
 
             // Save the preview results
             this.info.globalState.preview = {
-                stubs
+                stubs,
             };
 
             this.unsavedUpdates = true;

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
@@ -5,7 +5,7 @@ import { unsafeSVG } from "lit/directives/unsafe-svg.js";
 import folderOpenSVG from "../../../assets/folder_open.svg?raw";
 
 import { electron } from "../../../../electron/index.js";
-import { getSharedPath } from "../../../preview/NWBFilePreview.js";
+import { getSharedPath, removeFilePaths, truncateFilePaths } from "../../../preview/NWBFilePreview.js";
 const { shell } = electron;
 import { until } from "lit/directives/until.js";
 import { run } from "./utils.js";
@@ -13,22 +13,6 @@ import { InspectorList } from "../../../preview/inspector/InspectorList.js";
 import { getStubArray } from "./GuidedStubPreview.js";
 import { InstanceManager } from "../../../InstanceManager.js";
 
-const removeFilePaths = (arr) => {
-    return arr.map((o) => {
-        const copy = {...o}
-        delete copy.file_path;
-        return copy;
-    })
-}
-function truncateFilePaths(items, basepath) {
-    return items.map((o) => {
-        o = {...o}
-        o.file_path = o.file_path
-                        .replace(`${basepath}/`, "") // Mac
-                        .replace(`${basepath}\\`, ""); // Windows
-        return o;
-    })
-}
 
 const filter = (list, toFilter) => {
     return list.filter(o => {

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
@@ -1,0 +1,136 @@
+import { html } from "lit";
+import { Page } from "../../Page.js";
+
+import { unsafeSVG } from "lit/directives/unsafe-svg.js";
+import folderOpenSVG from "../../../assets/folder_open.svg?raw";
+
+import { electron } from "../../../../electron/index.js";
+import { getSharedPath } from "../../../preview/NWBFilePreview.js";
+const { shell } = electron;
+import { until } from "lit/directives/until.js";
+import { run } from "./utils.js";
+import { InspectorList } from "../../../preview/inspector/InspectorList.js";
+import { getStubArray } from "./GuidedStubPreview.js";
+import { InstanceManager } from "../../../InstanceManager.js";
+
+const removeFilePaths = (arr) => {
+    return arr.map((o) => {
+        const copy = {...o}
+        delete copy.file_path;
+        return copy;
+    })
+}
+function truncateFilePaths(items, basepath) {
+    return items.map((o) => {
+        o = {...o}
+        o.file_path = o.file_path
+                        .replace(`${basepath}/`, "") // Mac
+                        .replace(`${basepath}\\`, ""); // Windows
+        return o;
+    })
+}
+
+const filter = (list, toFilter) => {
+    return list.filter(o => {
+        return Object.entries(toFilter).map(([key, strOrArray]) => {
+            return (Array.isArray(strOrArray)) ? strOrArray.map(str => o[key].includes(str)) : o[key].includes(strOrArray)
+        }).flat().every(Boolean)
+    })
+}
+
+export class GuidedInspectorPage extends Page {
+    constructor(...args) {
+        super(...args);
+    }
+
+    header = {
+        subtitle: () => `${getStubArray(this.info.globalState.preview.stubs).length} Files`,
+        controls: () =>
+            html`<nwb-button
+                size="small"
+                @click=${() =>
+                    shell
+                        ? shell.showItemInFolder(
+                              getSharedPath(getStubArray(this.info.globalState.preview.stubs).map((o) => o.file))
+                          )
+                        : ""}
+                >${unsafeSVG(folderOpenSVG)}</nwb-button
+            >`,
+    };
+
+    // NOTE: We may want to trigger this whenever (1) this page is visited AND (2) data has been changed.
+    footer = {
+        next: "Preview Files"
+    };
+
+    render() {
+        const { globalState } = this.info
+        const { stubs, inspector } = globalState.preview
+
+        const opts = {}; // NOTE: Currently options are handled on the Python end until exposed to the user
+        const title = "Inspecting your file";
+
+        const fileArr = Object.entries(stubs)
+        .map(([subject, v]) =>
+            Object.entries(v).map(([session, info]) => {
+                return { subject, session, info };
+            })
+        )
+        .flat();
+        return html`
+                ${until(
+                    (async () => {
+                if (fileArr.length <= 1) {
+                        const items = inspector ?? removeFilePaths(this.unsavedUpdates = globalState.preview.inspector = await run("inspect_file", { nwbfile_path: fileArr[0].info.file, ...opts }, { title }))
+                        return new InspectorList({ items })
+                } 
+
+            const items = await (async () => {
+                const path = getSharedPath(fileArr.map((o) => o.info.file));
+                const report = inspector ?? (this.unsavedUpdates = globalState.preview.inspector = await run("inspect_folder", { path, ...opts }, { title: title + "s" }));
+                return truncateFilePaths(report, path);
+            })();
+
+            const _instances = fileArr.map(({ subject , session, info }) => {
+
+                const display = () => {
+                    const filtered = removeFilePaths(filter(items, { file_path: [`sub-${subject}`, `sub-${subject}_ses-${session}`]}))
+                    return new InspectorList({ items: filtered })
+                }
+
+                return {
+                    subject, 
+                    session, 
+                    display
+                }
+            });
+
+            const instances = _instances.reduce((acc, { subject, session, display }) => {
+                if (!acc[`sub-${subject}`]) acc[`sub-${subject}`] = {};
+                acc[`sub-${subject}`][`ses-${session}`] = display;
+                return acc;
+            }, {});
+
+            Object.keys(instances).forEach((subLabel) => {
+                instances[subLabel] = {
+                    ['All Files']: () => {
+                        const subItems = filter(items, { file_path: `${subLabel}/${subLabel}_ses-`})
+                        const path = getSharedPath(subItems.map((o) => o.file_path));
+                        return new InspectorList({ items: truncateFilePaths(subItems, path)})
+                    },
+                    ...instances[subLabel]
+                }
+            })
+
+            return new InstanceManager({ 
+                instances: {
+                    ['All Files']: () => new InspectorList({ items }),
+                    ...instances
+                } 
+            });
+        })(), '')}`
+    }
+}
+
+customElements.get("nwbguide-guided-inspector-page") ||
+    customElements.define("nwbguide-guided-inspector-page", GuidedInspectorPage);

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
@@ -12,6 +12,7 @@ import { run } from "./utils.js";
 import { InspectorList } from "../../../preview/inspector/InspectorList.js";
 import { getStubArray } from "./GuidedStubPreview.js";
 import { InstanceManager } from "../../../InstanceManager.js";
+import { path as nodePath } from "../../../../electron";
 
 const filter = (list, toFilter) => {
     return list.filter((o) => {
@@ -110,7 +111,7 @@ export class GuidedInspectorPage extends Page {
                 Object.keys(instances).forEach((subLabel) => {
                     instances[subLabel] = {
                         ["All Files"]: () => {
-                            const subItems = filter(items, { file_path: `${subLabel}/${subLabel}_ses-` });
+                            const subItems = filter(items, { file_path: `${subLabel}${nodePath.sep}${subLabel}_ses-` }); // NOTE: This will not run on web-only now
                             const path = getSharedPath(subItems.map((o) => o.file_path));
                             return new InspectorList({ items: truncateFilePaths(subItems, path) });
                         },

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -8,7 +8,7 @@ import { electron } from "../../../../electron/index.js";
 import { NWBFilePreview, getSharedPath } from "../../../preview/NWBFilePreview.js";
 const { shell } = electron;
 
-const getStubArray = (stubs) =>
+export const getStubArray = (stubs) =>
     Object.values(stubs)
         .map((o) => Object.values(o))
         .flat();
@@ -19,14 +19,14 @@ export class GuidedStubPreviewPage extends Page {
     }
 
     header = {
-        subtitle: () => `${getStubArray(this.info.globalState.stubs).length} Files`,
+        subtitle: () => `${getStubArray(this.info.globalState.preview.stubs).length} Files`,
         controls: () =>
             html`<nwb-button
                 size="small"
                 @click=${() =>
                     shell
                         ? shell.showItemInFolder(
-                              getSharedPath(getStubArray(this.info.globalState.stubs).map((o) => o.file))
+                              getSharedPath(getStubArray(this.info.globalState.preview.stubs).map((o) => o.file))
                           )
                         : ""}
                 >${unsafeSVG(folderOpenSVG)}</nwb-button
@@ -47,10 +47,10 @@ export class GuidedStubPreviewPage extends Page {
     };
 
     render() {
-        const { stubs, project } = this.info.globalState;
+        const { preview, project } = this.info.globalState;
 
-        return stubs
-            ? new NWBFilePreview({ project: project.name, files: stubs })
+        return preview.stubs
+            ? new NWBFilePreview({ project: project.name, files: preview.stubs })
             : html`<p style="text-align: center;">Your conversion preview failed. Please try again.</p>`;
     }
 }

--- a/src/renderer/src/stories/preview/NWBFilePreview.js
+++ b/src/renderer/src/stories/preview/NWBFilePreview.js
@@ -61,10 +61,11 @@ export class NWBFilePreview extends LitElement {
         `;
     }
 
-    constructor({ files = {}, project }) {
+    constructor({ files = {}, project, inspect = false }) {
         super();
         this.project = project;
         this.files = files;
+        this.inspect = inspect
     }
 
     createInstance = ({ subject, session, info }) => {
@@ -99,14 +100,11 @@ export class NWBFilePreview extends LitElement {
                             return acc;
                         }, {});
 
-                        return new InstanceManager({
-                            header: "Stub Files",
-                            instances,
-                        });
+                        return new InstanceManager({  instances });
                     }
                 })()}
             </div>
-            <div style="padding-left: 20px; display: flex; flex-direction: column;">
+            ${this.inspect ? html`<div style="padding-left: 20px; display: flex; flex-direction: column;">
                 <h3 style="padding: 10px; margin: 0; background: black; color: white;">Inspector Report</h3>
                 ${until(
                     (async () => {
@@ -114,23 +112,12 @@ export class NWBFilePreview extends LitElement {
 
                         const title = "Inspecting your file";
 
-                        const items = onlyFirstFile
-                            ? (
-                                  await run("inspect_file", { nwbfile_path: fileArr[0].info.file, ...opts }, { title })
-                              ).map((o) => {
-                                  delete o.file_path;
-                                  return o;
-                              }) // Inspect the first file
-                            : await (async () => {
-                                  const path = getSharedPath(fileArr.map((o) => o.info.file));
-                                  const report = await run("inspect_folder", { path, ...opts }, { title: title + "s" });
-                                  return report.map((o) => {
-                                      o.file_path = o.file_path
-                                                        .replace(`${path}/`, "") // Mac
-                                                        .replace(`${path}\\`, ""); // Windows
-                                      return o;
-                                  });
-                              })();
+                        const items = (
+                            await run("inspect_file", { nwbfile_path: fileArr[0].info.file, ...opts }, { title })
+                        ).map((o) => {
+                            delete o.file_path;
+                            return o;
+                        })
 
                         const list = new InspectorList({
                             items: items,
@@ -141,7 +128,7 @@ export class NWBFilePreview extends LitElement {
                     })(),
                     html`<small style="padding: 10px 25px;">Loading inspector report...</small>`
                 )}
-            </div>
+            </div>` : ''}
         </div>`;
     }
 }

--- a/src/renderer/src/stories/preview/NWBFilePreview.js
+++ b/src/renderer/src/stories/preview/NWBFilePreview.js
@@ -10,7 +10,7 @@ import { path } from "../../electron";
 export function getSharedPath(array) {
     array = array.map((str) => str.replace(/\\/g, "/")); // Convert to Mac-style path
     const mapped = array.map((str) => str.split("/"));
-    let shared = mapped.shift();
+    const shared = mapped.shift();
     mapped.forEach((arr, i) => {
         for (let j in arr) {
             if (arr[j] !== shared[j]) {

--- a/src/renderer/src/stories/preview/NWBFilePreview.js
+++ b/src/renderer/src/stories/preview/NWBFilePreview.js
@@ -25,22 +25,21 @@ export function getSharedPath(array) {
 
 export function truncateFilePaths(items, basepath) {
     return items.map((o) => {
-        o = {...o}
+        o = { ...o };
         o.file_path = o.file_path
-                        .replace(`${basepath}/`, "") // Mac
-                        .replace(`${basepath}\\`, ""); // Windows
+            .replace(`${basepath}/`, "") // Mac
+            .replace(`${basepath}\\`, ""); // Windows
         return o;
-    })
+    });
 }
-
 
 export const removeFilePaths = (arr) => {
     return arr.map((o) => {
-        const copy = {...o}
+        const copy = { ...o };
         delete copy.file_path;
         return copy;
-    })
-}
+    });
+};
 
 class NWBPreviewInstance extends LitElement {
     constructor({ file }, project) {
@@ -84,7 +83,7 @@ export class NWBFilePreview extends LitElement {
         super();
         this.project = project;
         this.files = files;
-        this.inspect = inspect
+        this.inspect = inspect;
     }
 
     createInstance = ({ subject, session, info }) => {
@@ -119,35 +118,44 @@ export class NWBFilePreview extends LitElement {
                             return acc;
                         }, {});
 
-                        return new InstanceManager({  instances });
+                        return new InstanceManager({ instances });
                     }
                 })()}
             </div>
-            ${this.inspect ? html`<div style="padding-left: 20px; display: flex; flex-direction: column;">
-                <h3 style="padding: 10px; margin: 0; background: black; color: white;">Inspector Report</h3>
-                ${until(
-                    (async () => {
-                        const opts = {}; // NOTE: Currently options are handled on the Python end until exposed to the user
+            ${this.inspect
+                ? html`<div style="padding-left: 20px; display: flex; flex-direction: column;">
+                      <h3 style="padding: 10px; margin: 0; background: black; color: white;">Inspector Report</h3>
+                      ${until(
+                          (async () => {
+                              const opts = {}; // NOTE: Currently options are handled on the Python end until exposed to the user
 
-                        const title = "Inspecting your file";
+                              const title = "Inspecting your file";
 
-                        const items = onlyFirstFile
-                            ? removeFilePaths(await run("inspect_file", { nwbfile_path: fileArr[0].info.file, ...opts }, { title })) // Inspect the first file
-                            : await (async () => truncateFilePaths(
-                                await run("inspect_folder", { path, ...opts }, { title: title + "s" }), 
-                                getSharedPath(fileArr.map((o) => o.info.file))
-                            ))();
+                              const items = onlyFirstFile
+                                  ? removeFilePaths(
+                                        await run(
+                                            "inspect_file",
+                                            { nwbfile_path: fileArr[0].info.file, ...opts },
+                                            { title }
+                                        )
+                                    ) // Inspect the first file
+                                  : await (async () =>
+                                        truncateFilePaths(
+                                            await run("inspect_folder", { path, ...opts }, { title: title + "s" }),
+                                            getSharedPath(fileArr.map((o) => o.info.file))
+                                        ))();
 
-                        const list = new InspectorList({
-                            items: items,
-                            listStyles: { maxWidth: "350px" },
-                        });
-                        list.style.padding = "10px";
-                        return list;
-                    })(),
-                    html`<small style="padding: 10px 25px;">Loading inspector report...</small>`
-                )}
-            </div>` : ''}
+                              const list = new InspectorList({
+                                  items: items,
+                                  listStyles: { maxWidth: "350px" },
+                              });
+                              list.style.padding = "10px";
+                              return list;
+                          })(),
+                          html`<small style="padding: 10px 25px;">Loading inspector report...</small>`
+                      )}
+                  </div>`
+                : ""}
         </div>`;
     }
 }

--- a/src/renderer/src/stories/preview/NWBFilePreview.js
+++ b/src/renderer/src/stories/preview/NWBFilePreview.js
@@ -10,7 +10,7 @@ import { path } from "../../electron";
 export function getSharedPath(array) {
     array = array.map((str) => str.replace(/\\/g, "/")); // Convert to Mac-style path
     const mapped = array.map((str) => str.split("/"));
-    const shared = mapped.shift();
+    let shared = mapped.shift();
     mapped.forEach((arr, i) => {
         for (let j in arr) {
             if (arr[j] !== shared[j]) {

--- a/src/renderer/src/stories/preview/inspector/InspectorList.js
+++ b/src/renderer/src/stories/preview/inspector/InspectorList.js
@@ -110,7 +110,7 @@ export class InspectorListItem extends LitElement {
             ${this.file_path ? html`<span id="filepath">${this.file_path}</span>` : ""}
             ${hasMetadata ? html`<span id="message">${this.message}</span>` : html`<p>${this.message}</p>`}
             ${hasMetadata
-                ? html`<small>${this.object_name}${hasObjectType ? ` (${this.object_type})` : ""} </small>`
+                ? html`<small>${hasObjectType ? `${this.object_type}` : ""} </small>`
                 : ""}
         `;
     }

--- a/src/renderer/src/stories/preview/inspector/InspectorList.js
+++ b/src/renderer/src/stories/preview/inspector/InspectorList.js
@@ -19,12 +19,29 @@ const sortList = (items) => {
         });
 };
 
+const aggregateMessages = (items) => {
+    let messages = {}
+    items.forEach(o => {
+        if (!messages[o.message]) messages[o.message] = []
+        messages[o.message].push(o)
+    })
+    return messages
+};
+
 export class InspectorList extends List {
     constructor({ items, listStyles }) {
+
+        const aggregatedItems = Object.values(aggregateMessages(items)).map((items) => {
+            const aggregate = {...items.pop()} // Create a base object for the aggregation
+            aggregate.files = [aggregate.file_path, ...items.map(o => o.file_path)]
+            return aggregate
+        })
+        
+
         super({
             editable: false,
             unordered: true,
-            items: sortList(items).map((o) => {
+            items: sortList(aggregatedItems).map((o) => {
                 const item = new InspectorListItem(o);
                 item.style.flexGrow = "1";
                 return { content: item };
@@ -56,6 +73,10 @@ export class InspectorListItem extends LitElement {
             }
 
             #filepath {
+                font-size: 10px;
+            }
+
+            #objectType {
                 font-size: 10px;
             }
 
@@ -107,11 +128,11 @@ export class InspectorListItem extends LitElement {
         const hasMetadata = hasObjectType && "object_name" in this;
 
         return html`
-            ${this.file_path ? html`<span id="filepath">${this.file_path}</span>` : ""}
-            ${hasMetadata ? html`<span id="message">${this.message}</span>` : html`<p>${this.message}</p>`}
             ${hasMetadata
-                ? html`<small>${hasObjectType ? `${this.object_type}` : ""} </small>`
-                : ""}
+            ? html`<span id="objectType">${hasObjectType ? `${this.object_type}` : ""} </span>`
+            : ""}
+            ${hasMetadata ? html`<span id="message">${this.message}</span>` : html`<p>${this.message}</p>`}
+            ${this.file_path ? html`<span id="filepath">${this.files && this.files.length > 1 ? `${this.files[0]} and ${this.files.length - 1} other files` : this.file_path}</span>` : ""}
         `;
     }
 }

--- a/src/renderer/src/stories/preview/inspector/InspectorList.js
+++ b/src/renderer/src/stories/preview/inspector/InspectorList.js
@@ -20,23 +20,21 @@ const sortList = (items) => {
 };
 
 const aggregateMessages = (items) => {
-    let messages = {}
-    items.forEach(o => {
-        if (!messages[o.message]) messages[o.message] = []
-        messages[o.message].push(o)
-    })
-    return messages
+    let messages = {};
+    items.forEach((o) => {
+        if (!messages[o.message]) messages[o.message] = [];
+        messages[o.message].push(o);
+    });
+    return messages;
 };
 
 export class InspectorList extends List {
     constructor({ items, listStyles }) {
-
         const aggregatedItems = Object.values(aggregateMessages(items)).map((items) => {
-            const aggregate = {...items.pop()} // Create a base object for the aggregation
-            aggregate.files = [aggregate.file_path, ...items.map(o => o.file_path)]
-            return aggregate
-        })
-        
+            const aggregate = { ...items.pop() }; // Create a base object for the aggregation
+            aggregate.files = [aggregate.file_path, ...items.map((o) => o.file_path)];
+            return aggregate;
+        });
 
         super({
             editable: false,
@@ -128,11 +126,15 @@ export class InspectorListItem extends LitElement {
         const hasMetadata = hasObjectType && "object_name" in this;
 
         return html`
-            ${hasMetadata
-            ? html`<span id="objectType">${hasObjectType ? `${this.object_type}` : ""} </span>`
-            : ""}
+            ${hasMetadata ? html`<span id="objectType">${hasObjectType ? `${this.object_type}` : ""} </span>` : ""}
             ${hasMetadata ? html`<span id="message">${this.message}</span>` : html`<p>${this.message}</p>`}
-            ${this.file_path ? html`<span id="filepath">${this.files && this.files.length > 1 ? `${this.files[0]} and ${this.files.length - 1} other files` : this.file_path}</span>` : ""}
+            ${this.file_path
+                ? html`<span id="filepath"
+                      >${this.files && this.files.length > 1
+                          ? `${this.files[0]} and ${this.files.length - 1} other files`
+                          : this.file_path}</span
+                  >`
+                : ""}
         `;
     }
 }


### PR DESCRIPTION
This PR builds on #326 by (1) breaking out an Inspect Files page from the Preview Files page, (2) aggregating messages in a way that is more consistent with the NWB Inspector text printout, and (3) allowing users to filter messages by subject, subject + session, or not at all.