### PR TITLE
Lower version pin on pydantic

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -9,7 +9,7 @@ dependencies:
   - numcodecs = 0.11.0
   # install these from conda-forge so that dependent packages get included in the distributable
   - jsonschema = 4.18.0  # installs jsonschema-specifications
-  - pydantic[email] = 2.0.2  # installs email-validator
+  - pydantic[email] = 1.10.12  # installs email-validator
   - pip
   - pip:
       - chardet == 5.1.0

--- a/environments/environment-MAC-arm64.yml
+++ b/environments/environment-MAC-arm64.yml
@@ -12,7 +12,7 @@ dependencies:
   - numpy  # may have x64/arm64 mismatch issues so install from conda-forge
   # install these from conda-forge so that dependent packages get included in the distributable
   - jsonschema = 4.18.0  # installs jsonschema-specifications
-  - pydantic[email] = 2.0.2  # installs email-validator
+  - pydantic[email] = 1.10.12  # installs email-validator
   - pip
   - pip:
       - chardet == 5.1.0

--- a/environments/environment-MAC.yml
+++ b/environments/environment-MAC.yml
@@ -9,7 +9,7 @@ dependencies:
   - numcodecs = 0.11.0
   # install these from conda-forge so that dependent packages get included in the distributable
   - jsonschema = 4.18.0  # installs jsonschema-specifications
-  - pydantic[email] = 2.0.2  # installs email-validator
+  - pydantic[email] = 1.10.12  # installs email-validator
   - pip
   - pip:
       - chardet == 5.1.0

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -8,7 +8,8 @@ dependencies:
   - PyInstaller = 5.13.0
   - pywin32 = 303
   - git = 2.20.1
-  - setuptools=58.0.4
+  - setuptools = 58.0.4
+  - pydantic[email] = 1.10.12 # installs email-validator
   - pip
   - pip:
       - chardet == 5.1.0
@@ -20,4 +21,3 @@ dependencies:
       - hdmf >= 3.7.0
       - pytest == 7.2.2
       - pytest-cov == 4.1.0
-      - email-validator == 2.0.0


### PR DESCRIPTION
Totally my bad for not catching this earlier

Now that it's not a `pip` dependency the `pip` resolution detector doesn't complain about an incompatibility; DANDI relies on `pydantic < 2.0` for the time being

Hopeful this will perhaps resolve the recursions depth issue too