### PR TITLE
Fix error in updating project name, edit error msg

### DIFF
--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -58,8 +58,6 @@ export const save = (page, overrides = {}) => {
 export const getEntries = () => {
     if (fs && !fs.existsSync(guidedProgressFilePath)) fs.mkdirSync(guidedProgressFilePath, { recursive: true }); //Check if progress folder exists. If not, create it.
     const progressFiles = fs ? fs.readdirSync(guidedProgressFilePath) : Object.keys(localStorage);
-    console.log(progressFiles)
-
     return progressFiles.filter((path) => path.slice(-5) === ".json");
 };
 

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -14,7 +14,7 @@ import { merge } from "../stories/pages/utils.js";
 import { updateAppProgress, updateFile } from "./update.js";
 import { updateURLParams } from "../../utils/url.js";
 
-import * as operations from './operations'
+import * as operations from "./operations";
 
 export * from "./update";
 
@@ -124,7 +124,7 @@ export const remove = async (name) => {
         focusCancel: true,
     });
 
-    if (result.isConfirmed) return operations.remove(name)
+    if (result.isConfirmed) return operations.remove(name);
 
     return false;
 };

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -14,6 +14,8 @@ import { merge } from "../stories/pages/utils.js";
 import { updateAppProgress, updateFile } from "./update.js";
 import { updateURLParams } from "../../utils/url.js";
 
+import * as operations from './operations'
+
 export * from "./update";
 
 class GlobalAppConfig {
@@ -56,6 +58,8 @@ export const save = (page, overrides = {}) => {
 export const getEntries = () => {
     if (fs && !fs.existsSync(guidedProgressFilePath)) fs.mkdirSync(guidedProgressFilePath, { recursive: true }); //Check if progress folder exists. If not, create it.
     const progressFiles = fs ? fs.readdirSync(guidedProgressFilePath) : Object.keys(localStorage);
+    console.log(progressFiles)
+
     return progressFiles.filter((path) => path.slice(-5) === ".json");
 };
 
@@ -122,24 +126,7 @@ export const remove = async (name) => {
         focusCancel: true,
     });
 
-    if (result.isConfirmed) {
-        //Get the path of the progress file to delete
-        const progressFilePathToDelete = joinPath(guidedProgressFilePath, name + ".json");
-
-        //delete the progress file
-        if (fs) fs.unlinkSync(progressFilePathToDelete);
-        else localStorage.removeItem(progressFilePathToDelete);
-
-        if (fs) {
-            // delete default stub location
-            fs.rmSync(joinPath(stubSaveFolderPath, name), { recursive: true, force: true });
-
-            // delete default conversion location
-            fs.rmSync(joinPath(conversionSaveFolderPath, name), { recursive: true, force: true });
-        }
-
-        return true;
-    }
+    if (result.isConfirmed) return operations.remove(name)
 
     return false;
 };

--- a/src/renderer/src/progress/operations.js
+++ b/src/renderer/src/progress/operations.js
@@ -2,22 +2,21 @@ import { joinPath } from "../globals";
 import { conversionSaveFolderPath, guidedProgressFilePath, stubSaveFolderPath } from "../dependencies/simple";
 import { fs } from "../electron";
 
-
 export const remove = (name) => {
-     //Get the path of the progress file to delete
-     const progressFilePathToDelete = joinPath(guidedProgressFilePath, name + ".json");
+    //Get the path of the progress file to delete
+    const progressFilePathToDelete = joinPath(guidedProgressFilePath, name + ".json");
 
-     //delete the progress file
-     if (fs) fs.unlinkSync(progressFilePathToDelete);
-     else localStorage.removeItem(progressFilePathToDelete);
+    //delete the progress file
+    if (fs) fs.unlinkSync(progressFilePathToDelete);
+    else localStorage.removeItem(progressFilePathToDelete);
 
-     if (fs) {
-         // delete default stub location
-         fs.rmSync(joinPath(stubSaveFolderPath, name), { recursive: true, force: true });
+    if (fs) {
+        // delete default stub location
+        fs.rmSync(joinPath(stubSaveFolderPath, name), { recursive: true, force: true });
 
-         // delete default conversion location
-         fs.rmSync(joinPath(conversionSaveFolderPath, name), { recursive: true, force: true });
-     }
+        // delete default conversion location
+        fs.rmSync(joinPath(conversionSaveFolderPath, name), { recursive: true, force: true });
+    }
 
-     return true;
-}
+    return true;
+};

--- a/src/renderer/src/progress/operations.js
+++ b/src/renderer/src/progress/operations.js
@@ -1,0 +1,23 @@
+import { joinPath } from "../globals";
+import { conversionSaveFolderPath, guidedProgressFilePath, stubSaveFolderPath } from "../dependencies/simple";
+import { fs } from "../electron";
+
+
+export const remove = (name) => {
+     //Get the path of the progress file to delete
+     const progressFilePathToDelete = joinPath(guidedProgressFilePath, name + ".json");
+
+     //delete the progress file
+     if (fs) fs.unlinkSync(progressFilePathToDelete);
+     else localStorage.removeItem(progressFilePathToDelete);
+
+     if (fs) {
+         // delete default stub location
+         fs.rmSync(joinPath(stubSaveFolderPath, name), { recursive: true, force: true });
+
+         // delete default conversion location
+         fs.rmSync(joinPath(conversionSaveFolderPath, name), { recursive: true, force: true });
+     }
+
+     return true;
+}

--- a/src/renderer/src/progress/update.js
+++ b/src/renderer/src/progress/update.js
@@ -2,15 +2,15 @@ import { updateURLParams } from "../../utils/url.js";
 import { guidedProgressFilePath } from "../dependencies/simple.js";
 import { fs } from "../electron/index.js";
 import { joinPath } from "../globals.js";
-import { get } from "./index.js";
+import { get, hasEntry } from "./index.js";
 
 export const update = (newDatasetName, previousDatasetName) => {
-    //If updataing the dataset, update the old banner image path with a new one
+    //If updating the dataset, update the old banner image path with a new one
     if (previousDatasetName) {
-        if (previousDatasetName === newDatasetName) return "No changes made to dataset name";
+        if (previousDatasetName === newDatasetName) return;
 
         if (hasEntry(newDatasetName))
-            throw new Error("An existing progress file already exists with that name. Please choose a different name.");
+            throw new Error("An existing project already exists with that name. Please choose a different name.");
 
         // update old progress file with new dataset name
         const oldProgressFilePath = `${guidedProgressFilePath}/${previousDatasetName}.json`;
@@ -20,9 +20,7 @@ export const update = (newDatasetName, previousDatasetName) => {
             localStorage.setItem(newProgressFilePath, localStorage.getItem(oldProgressFilePath));
             localStorage.removeItem(oldProgressFilePath);
         }
-
-        return "Dataset name updated";
-    } else throw new Error("No previous dataset name provided");
+    } else throw new Error("No previous project name provided");
 };
 export const updateAppProgress = (
     pageId,

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
@@ -61,7 +61,7 @@ export class GuidedNewDatasetPage extends Page {
                 const has = await hasEntry(name);
                 if (has) {
                     this.notify(
-                        "An existing progress file already exists with that name. Please choose a different name.",
+                        "An existing project already exists with that name. Please choose a different name.",
                         "error"
                     );
                     return;

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -25,5 +25,3 @@ test('pipeline renaming works', () => rename(renameName, initialName))
 
 // delete pipeline
 test('pipeline deletion works', () => remove(renameName))
-
-

--- a/tests/progress.test.ts
+++ b/tests/progress.test.ts
@@ -1,4 +1,29 @@
-import { test } from 'vitest'
-import { updateAppProgress } from '../src/renderer/src/progress/update'
+import { expect, test } from 'vitest'
+import { updateAppProgress, updateFile, rename } from '../src/renderer/src/progress/update'
+import { get } from '../src/renderer/src/progress'
+import { remove } from '../src/renderer/src/progress/operations'
 
 test('updates to app progress do not fail', () => updateAppProgress('/', {}))
+
+const initialName = '.progressTestPipelineName'
+const renameName = initialName + 2
+const info = { random: Math.random() }
+
+// Remove before tests
+remove(initialName)
+remove(renameName)
+
+// create pipeline
+test('pipeline creation works', () => {
+    updateFile(initialName, () => info)
+    const result = get(initialName)
+    expect(result.random).toEqual(info.random) // NOTE: Result has an extra lastModified field
+})
+
+// rename pipeline
+test('pipeline renaming works', () => rename(renameName, initialName))
+
+// delete pipeline
+test('pipeline deletion works', () => remove(renameName))
+
+


### PR DESCRIPTION
Fix #385.

- Returning to "Project details" page and:
	- not changing the name no longer results in green popup box that says "No changes made to dataset name"
	- changing the name to an allowed name no longer results in green popup box that says "Dataset name updated"
	- changing the name to one that is already taken no longer results in ReferenceError (it will now result in error that says "An existing project already exists with that name. Please choose a different name.")
- Changed "progress file" -> "project" in related error messages