### PR TITLE
Python-side fix for expecting NaN in JSON

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -2,6 +2,7 @@
 import os
 import json
 import math
+import copy
 from datetime import datetime
 from typing import Dict, Optional  # , List, Union # TODO: figure way to add these back in without importing other class
 from shutil import rmtree, copytree
@@ -57,9 +58,6 @@ def resolve_references(schema, root_schema=None):
 
 
 def replace_none_with_nan(json_object, json_schema):
-    import math
-    import copy
-
     """
     Recursively search a JSON object and replace None values with NaN where appropriate.
 

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -12,6 +12,7 @@ from .info import STUB_SAVE_FOLDER_PATH, CONVERSION_SAVE_FOLDER_PATH, TUTORIAL_S
 
 announcer = MessageAnnouncer()
 
+
 def replace_nan_with_none(data):
     if isinstance(data, dict):
         # If it's a dictionary, iterate over its items and replace NaN values with None
@@ -23,10 +24,11 @@ def replace_nan_with_none(data):
         return None  # Replace NaN with None
     else:
         return data
-    
-def resolve_references(schema, root_schema = None):
 
+
+def resolve_references(schema, root_schema=None):
     from jsonschema import RefResolver
+
     """
     Recursively resolve references in a JSON schema based on the root schema.
 
@@ -45,11 +47,10 @@ def resolve_references(schema, root_schema = None):
         resolver = RefResolver.from_schema(root_schema)
         return resolver.resolve(schema["$ref"])[1]
 
-    
     if "properties" in schema:
         for key, prop_schema in schema["properties"].items():
             schema["properties"][key] = resolve_references(prop_schema, root_schema)
-    
+
     if "items" in schema:
         schema["items"] = resolve_references(schema["items"], root_schema)
 
@@ -57,7 +58,6 @@ def resolve_references(schema, root_schema = None):
 
 
 def replace_none_with_nan(json_object, json_schema):
-    
     import math
     import copy
 
@@ -71,6 +71,7 @@ def replace_none_with_nan(json_object, json_schema):
     Returns:
         dict: The modified JSON object with None values replaced by NaN.
     """
+
     def replace_none_recursive(obj, schema):
         if isinstance(obj, dict):
             for key, value in obj.items():
@@ -364,7 +365,9 @@ def convert_to_nwb(info: dict) -> str:
     if "Ecephys" not in info["metadata"]:
         info["metadata"].update(Ecephys=dict())
 
-    resolved_metadata = replace_none_with_nan(info["metadata"], converter.get_metadata_schema()) # Ensure Ophys NaN values are resolved
+    resolved_metadata = replace_none_with_nan(
+        info["metadata"], converter.get_metadata_schema()
+    )  # Ensure Ophys NaN values are resolved
 
     # if is_supported_recording_interface(recording_interface, info["metadata"]):
     #     electrode_column_results = ecephys_metadata["ElectrodeColumns"]

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -27,8 +27,6 @@ def replace_nan_with_none(data):
 
 
 def resolve_references(schema, root_schema=None):
-    from jsonschema import RefResolver
-
     """
     Recursively resolve references in a JSON schema based on the root schema.
 
@@ -39,6 +37,7 @@ def resolve_references(schema, root_schema=None):
     Returns:
         dict: The resolved JSON schema.
     """
+    from jsonschema import RefResolver
 
     if root_schema is None:
         root_schema = schema

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1,6 +1,7 @@
 """Collection of utility functions used by the NeuroConv Flask API."""
 import os
 import json
+import math
 from datetime import datetime
 from typing import Dict, Optional  # , List, Union # TODO: figure way to add these back in without importing other class
 from shutil import rmtree, copytree
@@ -10,6 +11,82 @@ from sse import MessageAnnouncer
 from .info import STUB_SAVE_FOLDER_PATH, CONVERSION_SAVE_FOLDER_PATH, TUTORIAL_SAVE_FOLDER_PATH
 
 announcer = MessageAnnouncer()
+
+def replace_nan_with_none(data):
+    if isinstance(data, dict):
+        # If it's a dictionary, iterate over its items and replace NaN values with None
+        return {key: replace_nan_with_none(value) for key, value in data.items()}
+    elif isinstance(data, list):
+        # If it's a list, iterate over its elements and replace NaN values with None
+        return [replace_nan_with_none(item) for item in data]
+    elif isinstance(data, (float, int)) and (data != data):
+        return None  # Replace NaN with None
+    else:
+        return data
+    
+def resolve_references(schema, root_schema = None):
+
+    from jsonschema import RefResolver
+    """
+    Recursively resolve references in a JSON schema based on the root schema.
+
+    Args:
+        schema (dict): The JSON schema to resolve.
+        root_schema (dict): The root JSON schema.
+
+    Returns:
+        dict: The resolved JSON schema.
+    """
+
+    if root_schema is None:
+        root_schema = schema
+
+    if "$ref" in schema:
+        resolver = RefResolver.from_schema(root_schema)
+        return resolver.resolve(schema["$ref"])[1]
+
+    
+    if "properties" in schema:
+        for key, prop_schema in schema["properties"].items():
+            schema["properties"][key] = resolve_references(prop_schema, root_schema)
+    
+    if "items" in schema:
+        schema["items"] = resolve_references(schema["items"], root_schema)
+
+    return schema
+
+
+def replace_none_with_nan(json_object, json_schema):
+    
+    import math
+    import copy
+
+    """
+    Recursively search a JSON object and replace None values with NaN where appropriate.
+
+    Args:
+        json_object (dict): The JSON object to search and modify.
+        json_schema (dict): The JSON schema to validate against.
+
+    Returns:
+        dict: The modified JSON object with None values replaced by NaN.
+    """
+    def replace_none_recursive(obj, schema):
+        if isinstance(obj, dict):
+            for key, value in obj.items():
+                if key in schema.get("properties", {}):
+                    prop_schema = schema["properties"][key]
+                    if prop_schema.get("type") == "number" and value is None:
+                        obj[key] = math.nan
+                    else:
+                        replace_none_recursive(value, prop_schema)
+        elif isinstance(obj, list):
+            for item in obj:
+                replace_none_recursive(item, schema.get("items", {}))
+
+        return obj
+
+    return replace_none_recursive(copy.deepcopy(json_object), resolve_references(copy.deepcopy(json_schema)))
 
 
 def locate_data(info: dict) -> dict:
@@ -154,7 +231,7 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
     if "Ecephys" in schema["properties"]:
         schema["properties"].pop("Ecephys", dict())
 
-    return json.loads(json.dumps(dict(results=metadata, schema=schema), cls=NWBMetaDataEncoder))
+    return json.loads(json.dumps(replace_nan_with_none(dict(results=metadata, schema=schema)), cls=NWBMetaDataEncoder))
 
 
 def get_check_function(check_function_name: str) -> callable:
@@ -287,6 +364,8 @@ def convert_to_nwb(info: dict) -> str:
     if "Ecephys" not in info["metadata"]:
         info["metadata"].update(Ecephys=dict())
 
+    resolved_metadata = replace_none_with_nan(info["metadata"], converter.get_metadata_schema()) # Ensure Ophys NaN values are resolved
+
     # if is_supported_recording_interface(recording_interface, info["metadata"]):
     #     electrode_column_results = ecephys_metadata["ElectrodeColumns"]
     #     electrode_results = ecephys_metadata["Electrodes"]
@@ -302,7 +381,7 @@ def convert_to_nwb(info: dict) -> str:
 
     # Actually run the conversion
     converter.run_conversion(
-        metadata=info["metadata"],
+        metadata=resolved_metadata,
         nwbfile_path=resolved_output_path,
         overwrite=info.get("overwrite", False),
         conversion_options=options,

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -105,12 +105,7 @@ export class GuidedMetadataPage extends ManagedPage {
             results,
             globals: aggregateGlobalMetadata,
 
-            ignore: 
-            [
-                "Ophys", 
-                "subject_id", 
-                "session_id"
-            ],
+            ignore: ["Ophys", "subject_id", "session_id"],
 
             conditionalRequirements: [
                 {

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -105,7 +105,12 @@ export class GuidedMetadataPage extends ManagedPage {
             results,
             globals: aggregateGlobalMetadata,
 
-            ignore: ["subject_id", "session_id"],
+            ignore: 
+            [
+                "Ophys", 
+                "subject_id", 
+                "session_id"
+            ],
 
             conditionalRequirements: [
                 {

--- a/src/renderer/src/validation/validation.json
+++ b/src/renderer/src/validation/validation.json
@@ -23,6 +23,10 @@
         "session_start_time": ["check_session_start_time_future_date", "check_session_start_time_old_date"]
     },
 
+    "Ophys": {
+        "*": false
+    },
+
     "Ecephys": {
         "*": false,
         "ElectrodeGroup": {


### PR DESCRIPTION
This PR relies on Python instead of JavaScript to handle expected NaN values in the JSON metadata (unlike #374). 

Instead of allowing non-compliant JSON on the browser (which doesn't work when passing the object back to Python), this approach replaces `None` values where numbers are expected with `NaN` on the Python side, while converting `NaN` values to `None` before passing to JavaScript.

Since this is primarily testing Ophys interfaces (#177), the `Ophys` metadata field is ignored in this PR so we can work on those interactions in a follow-up (related to #176).