### PR TITLE
Correct Neuroconv Schema Inconsistency

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -88,7 +88,7 @@ def replace_none_with_nan(json_object, json_schema):
                         coerce_schema_compliance_recursive(value, prop_schema)
         elif isinstance(obj, list):
             for item in obj:
-                coerce_schema_compliance_recursive(item, schema.get("items", {}))
+                coerce_schema_compliance_recursive(item, schema.get("items", schema if 'properties' else {})) # NEUROCONV PATCH
 
         return obj
 

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -186,6 +186,7 @@ export class JSONSchemaInput extends LitElement {
             const fileSystemFormat = isFilesystemSelector(itemSchema.format);
             if (fileSystemFormat) return createFilesystemSelector(fileSystemFormat);
             else if (isTable) {
+
                 const tableMetadata = {
                     schema: itemSchema,
                     data: this.value,
@@ -197,7 +198,7 @@ export class JSONSchemaInput extends LitElement {
                             (this.onValidate
                                 ? this.onValidate()
                                 : this.form
-                                ? this.form.validateOnChange(key, parent, fullPath, v)
+                                ? this.form.validateOnChange(key, parent, [...this.form.base, ...fullPath], v)
                                 : "")
                         );
                     },

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -110,7 +110,11 @@ export class GuidedMetadataPage extends ManagedPage {
             results,
             globals: aggregateGlobalMetadata,
 
-            ignore: ["Ophys", "subject_id", "session_id"],
+            ignore: [
+                "Ophys",
+                "subject_id", 
+                "session_id"
+            ],
 
             conditionalRequirements: [
                 {
@@ -128,7 +132,7 @@ export class GuidedMetadataPage extends ManagedPage {
                 this.#checkAllLoaded();
             },
 
-            onUpdate: (...args) => {
+            onUpdate: () => {
                 this.unsavedUpdates = true;
             },
 

--- a/src/renderer/src/stories/pages/guided-mode/data/utils.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/utils.js
@@ -29,10 +29,18 @@ export function resolveProperties(properties = {}, target, globals = {}) {
 
     for (let name in properties) {
         const info = properties[name];
+
+        // NEUROCONV PATCH: Correct for incorrect array schema
+        if (info.properties && info.type === 'array') {
+            info.items = { type: "object", properties: info.properties, required: info.required }
+            delete info.properties
+        }
+
         const props = info.properties;
 
         if (!(name in target)) {
             if (props) target[name] = {}; // Regisiter new interfaces in results
+            if (info.type === 'array') target[name] = [] // Auto-populate arrays
 
             // Apply global or default value if empty
             if (name in globals) target[name] = globals[name];


### PR DESCRIPTION
This PR extends #406 to see if we could get a successful conversion to run by fixing the GUIDE's interpretation of the returned schema. Transforming the schema so the anomalous `properties` field in a `array` type is transformed into the `items` fields works to allow conversions.

 **Note:** The NWB Inspector doesn't like the resulting file, though, as the following error is thrown:
```
[main-process]: [2023-09-29 11:59:28,094] ERROR in app: Exception on /neuroconv/inspect_file [POST]
Traceback (most recent call last):
  File "/Users/garrettflynn/Documents/Github/nwb-guide/pyflask/apis/neuroconv.py", line 150, in post
    list(
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/nwbinspector/nwbinspector.py", line 555, in inspect_nwbfile
    validation_errors = pynwb.validate(io=io)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/utils.py", line 648, in func_call
    return func(**pargs)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/pynwb/validate.py", line 132, in validate
    validation_errors = _validate_helper(io=io, namespace=namespace or CORE_NAMESPACE)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/pynwb/validate.py", line 29, in _validate_helper
    return validator.validate(builder)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/utils.py", line 644, in func_call
    return func(args[0], **pargs)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 250, in validate
    return validator.validate(builder)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/utils.py", line 644, in func_call
    return func(args[0], **pargs)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 425, in validate
    errors.extend(self.__validate_children(builder))
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 451, in __validate_children
    yield from self.__validate_child_builder(child_spec, child_builder, parent_builder)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 500, in __validate_child_builder
    yield from child_validator.validate(child_builder)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/utils.py", line 644, in func_call
    return func(args[0], **pargs)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 425, in validate
    errors.extend(self.__validate_children(builder))
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 451, in __validate_children
    yield from self.__validate_child_builder(child_spec, child_builder, parent_builder)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 500, in __validate_child_builder
    yield from child_validator.validate(child_builder)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/utils.py", line 644, in func_call
    return func(args[0], **pargs)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 388, in validate
    dtype = get_type(data)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/hdmf/validate/validator.py", line 129, in get_type
    return get_type(data[0])
  File "h5py/_objects.pyx", line 54, in h5py._objects.with_phil.wrapper
  File "h5py/_objects.pyx", line 55, in h5py._objects.with_phil.wrapper
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/h5py/_hl/dataset.py", line 831, in __getitem__
    selection = sel.select(self.shape, args, dataset=self)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/h5py/_hl/selections.py", line 82, in select
    return selector.make_selection(args)
  File "h5py/_selector.pyx", line 282, in h5py._selector.Selector.make_selection
  File "h5py/_selector.pyx", line 151, in h5py._selector.Selector.apply_args
IndexError: Index (0) out of range for empty dimension
```