### PR TITLE
Ensure server shutdown without multithreading

### DIFF
--- a/pyflask/app.py
+++ b/pyflask/app.py
@@ -2,7 +2,8 @@
 import sys
 import json
 import multiprocessing
-from os.path import sep
+from os import kill, getpid
+from signal import SIGINT
 from logging import Formatter, DEBUG
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
@@ -96,7 +97,7 @@ class Shutdown(Resource):
         api.logger.info("Shutting down server")
 
         if func is None:
-            print("Not running with the Werkzeug Server")
+            kill(getpid(), SIGINT)
             return
 
         func()


### PR DESCRIPTION
Another quick fix for #408 by ensuring that at least _some_ command to shutdown the server is attempted if this endpoint is called. Tested in development and it definitely quits right away.