### PR TITLE
Fix @electron/remote

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
   },
   "license": "MIT",
   "dependencies": {
+    "@electron/remote": "^2.0.11",
     "@fortawesome/fontawesome-free": "^5.15.3",
     "@sweetalert2/theme-bulma": "^4.0.3",
     "chokidar": "^3.5.3",
@@ -153,7 +154,6 @@
   },
   "devDependencies": {
     "@electron-toolkit/utils": "^2.0.1",
-    "@electron/remote": "^2.0.11",
     "@storybook/addon-essentials": "^7.0.0-beta.62",
     "@storybook/addon-links": "^7.0.0-beta.62",
     "@storybook/blocks": "^7.0.0-beta.62",


### PR DESCRIPTION
This PR fixes the issue we had resolving `@electron/remote` in production because it was contained in `devDependencies`, which are not carried over.