### PR TITLE
Add instructions to run on unsupported Linux machines

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,15 @@ Run the `setup.exe` file and follow all instructions.
 
 Run the `.dmg` file and follow all instructions to move the file into your Applications folder.
 
-### Ubuntu - Graphical Interface
+### Ubuntu
+
+> **Note:** If you're running the `.AppImage` and the app window clears to a white screen within a few seconds of starting, you will need to follow the [Developer Instructions](#developer-installation) on the [linux-fix](https://github.com/neurodatawithoutborders/nwb-guide/tree/linux-fix) branch of the NWB GUIDE.
+
+#### Graphical Interface
 
 Right-click the `.AppImage` file, navigate to `permissions`, and check any box which mentions 'run as executable'.
 
-### Ubuntu - CLI
+#### Ubuntu - CLI
 
 From the terminal, simply type
 
@@ -54,6 +58,7 @@ Where you are using version `X.Y.Z`; then execute by calling
 ```
 ./nwb-guide-X.Y.Z.AppImage
 ```
+
 
 
 


### PR DESCRIPTION
This PR is a temporary fix for an issue where the app window stalls / clears a few seconds after start on certain Linux machines. 

We have opened a branch ([fix-linux](https://github.com/neurodatawithoutborders/nwb-guide/tree/fix-linux)) that implements the minimum fix for this issue—but cannot itself be built into a distributable.

This behavior is similar to that found on https://github.com/electron/electron/issues/27824. We can try building a minimal Electron app to replicate this behavior if we'd like to discover a better fix. The behaviors noted already are: 
- Removing preload and renderer files from the equation entirely still results in the stall / clear behavior—so this almost definitely has to do with the main process.