### PR TITLE
Fix Config Loading (NWB Inspector)

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -525,7 +525,7 @@ def generate_dataset(test_data_directory_path: str):
 
 
 def inspect_nwb_file(payload):
-    from nwbinspector import inspect_nwbfile
+    from nwbinspector import inspect_nwbfile, load_config
     from nwbinspector.nwbinspector import InspectorOutputJSONEncoder
 
     messages = list(
@@ -534,7 +534,7 @@ def inspect_nwb_file(payload):
                 "check_description",
                 "check_data_orientation",
             ],  # TODO: remove when metadata control is exposed
-            config="dandi",
+            config=load_config(filepath_or_keyword="dandi"),
             **payload,
         )
     )
@@ -543,7 +543,7 @@ def inspect_nwb_file(payload):
 
 
 def inspect_nwb_folder(payload):
-    from nwbinspector import inspect_all
+    from nwbinspector import inspect_all, load_config
     from nwbinspector.nwbinspector import InspectorOutputJSONEncoder
 
     messages = list(
@@ -553,7 +553,7 @@ def inspect_nwb_folder(payload):
                 "check_description",
                 "check_data_orientation",
             ],  # TODO: remove when metadata control is exposed
-            config="dandi",
+            config=load_config(filepath_or_keyword="dandi"),
             **payload,
         )
     )


### PR DESCRIPTION
This PR ensures that the DANDI configuration is directly passed to the NWB Inspector, instead of the related "dandi" key. 

This fixes the following error when attempting to run the Inspector: 
<img width="810" alt="Screenshot 2023-10-16 at 12 44 52 PM" src="https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/207ef950-ea69-4b63-b283-0f983987e2cb">
