### PR TITLE
Add NeuralynxSortingInterface

### DIFF
--- a/guideGlobalMetadata.json
+++ b/guideGlobalMetadata.json
@@ -30,6 +30,7 @@
         "PlexonSortingInterface",
         "AxonaRecordingInterface",
         "NeuralynxRecordingInterface",
-        "AlphaOmegaRecordingInterface"
+        "AlphaOmegaRecordingInterface",
+        "NeuralynxSortingInterface"
     ]
 }


### PR DESCRIPTION
This PR adds the NeuralynxSortingInterface to the allowed interfaces. However, this currently fails on the test data with the following error when attempting to create a stub preview:

![Screenshot 2023-10-17 at 11 56 59 AM](https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/b1d4609a-18c2-4708-82f1-798b02b4cbb1)

## Full Error
```
[main-process]: [2023-10-17 11:55:15,960] ERROR in app: Exception on /neuroconv/convert [POST]
Traceback (most recent call last):
  File "/Users/garrettflynn/Documents/Github/nwb-guide/pyflask/apis/neuroconv.py", line 89, in post
    return convert_to_nwb(neuroconv_api.payload)
  File "/Users/garrettflynn/Documents/Github/nwb-guide/pyflask/manageNeuroconv/manage_neuroconv.py", line 392, in convert_to_nwb
    converter.run_conversion(
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/neuroconv/nwbconverter.py", line 160, in run_conversion
    self.add_to_nwbfile(nwbfile_out, metadata, conversion_options)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/neuroconv/nwbconverter.py", line 114, in add_to_nwbfile
    data_interface.add_to_nwbfile(
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py", line 316, in add_to_nwbfile
    sorting_extractor = self.subset_sorting()
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py", line 218, in subset_sorting
    [
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/neuroconv/datainterfaces/ecephys/basesortingextractorinterface.py", line 221, in <listcomp>
    for x in [self.sorting_extractor.get_unit_spike_train(y)]
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/spikeinterface/core/basesorting.py", line 110, in get_unit_spike_train
    segment_index = self._check_segment_index(segment_index)
  File "/opt/anaconda3/envs/nwb-guide/lib/python3.9/site-packages/spikeinterface/core/base.py", line 78, in _check_segment_index
    raise ValueError("Multi-segment object. Provide 'segment_index'")
ValueError: Multi-segment object. Provide 'segment_index'
```