### PR TITLE
Exclude Interfaces from Selection Interface

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -133,15 +133,12 @@ def get_all_interface_info() -> dict:
     from neuroconv.datainterfaces import interface_list
 
     exclude_interfaces_from_selection = [
-
         # Deprecated
         "SpikeGLXLFP",
-
         # Aliased
         "CEDRecording",
         "OpenEphysBinaryRecording",
         "OpenEphysLegacyRecording",
-
         # Ignored
         "AxonaPositionData",
         "AxonaUnitRecording",
@@ -150,8 +147,7 @@ def get_all_interface_info() -> dict:
         "Hdf5Imaging",
         "MaxOneRecording",
         "OpenEphysSorting",
-        "SimaSegmentation"
-
+        "SimaSegmentation",
     ]  # Should have 'interface' stripped from name
 
     interfaces_to_load = {interface.__name__.replace("Interface", ""): interface for interface in interface_list}

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -132,7 +132,27 @@ def get_all_interface_info() -> dict:
     """Format an information structure to be used for selecting interfaces based on modality and technique."""
     from neuroconv.datainterfaces import interface_list
 
-    exclude_interfaces_from_selection = ["SpikeGLXLFP"]  # Should have 'interface' stripped from name
+    exclude_interfaces_from_selection = [
+
+        # Deprecated
+        "SpikeGLXLFP",
+
+        # Aliased
+        "CEDRecording",
+        "OpenEphysBinaryRecording",
+        "OpenEphysLegacyRecording",
+
+        # Ignored
+        "AxonaPositionData",
+        "AxonaUnitRecording",
+        "CsvTimeIntervals",
+        "ExcelTimeIntervals",
+        "Hdf5Imaging",
+        "MaxOneRecording",
+        "OpenEphysSorting",
+        "SimaSegmentation"
+
+    ]  # Should have 'interface' stripped from name
 
     interfaces_to_load = {interface.__name__.replace("Interface", ""): interface for interface in interface_list}
     for excluded_interface in exclude_interfaces_from_selection:


### PR DESCRIPTION
This PR excludes ignored, deprecated, and aliased interfaces from those passed throughout the GUIDE. This results in their exclusion from the interface selection page.