### PR TITLE
Add better exclusion control

### DIFF
--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -519,7 +519,8 @@ export class JSONSchemaForm extends LitElement {
                         if (typeof v === "string") return v === key;
                         else return v.test(key);
                     })
-                ) return false;
+                )
+                    return false;
                 if (this.showLevelOverride >= path.length) return isRenderable(key, value);
                 if (required[key]) return isRenderable(key, value);
                 if (this.#getLink([...this.base, ...path, key])) return isRenderable(key, value);

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -514,7 +514,12 @@ export class JSONSchemaForm extends LitElement {
         const res = entries
             .map(([key, value]) => {
                 if (!value.properties && key === "definitions") return false; // Skip definitions
-                if (this.ignore.includes(key)) return false;
+                if (
+                    this.ignore.find((v) => {
+                        if (typeof v === "string") return v === key;
+                        else return v.test(key);
+                    })
+                ) return false;
                 if (this.showLevelOverride >= path.length) return isRenderable(key, value);
                 if (required[key]) return isRenderable(key, value);
                 if (this.#getLink([...this.base, ...path, key])) return isRenderable(key, value);

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -110,7 +110,14 @@ export class GuidedMetadataPage extends ManagedPage {
             results,
             globals: aggregateGlobalMetadata,
 
-            ignore: ["Ophys", "subject_id", "session_id"],
+            ignore: [
+                "Ophys", // Always ignore ophys metadata (for now)
+                "Icephys", // Always ignore icephys metadata (for now)
+                "Behavior", // Always ignore behavior metadata (for now)
+                new RegExp("ndx-.+"), // Ignore all ndx extensions
+                "subject_id",
+                "session_id",
+            ],
 
             conditionalRequirements: [
                 {


### PR DESCRIPTION
Addresses comments in #449 and moves changes originating in #446 to ensure file metadata can always be reliably excluded.