### PR TITLE
Update headers for search categories

### DIFF
--- a/.github/workflows/add-to-catalystneuro-dashboard.yml
+++ b/.github/workflows/add-to-catalystneuro-dashboard.yml
@@ -1,0 +1,19 @@
+name: Add Issue or Pull Request to Dashboard
+
+on:
+  issues:
+    types:
+      - opened
+  pull_request:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue or pull request to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v0.5.0
+        with:
+          project-url: https://github.com/orgs/catalystneuro/projects/3
+          github-token: ${{ secrets.PROJECT_TOKEN }}

--- a/.storybook/preview-head.html
+++ b/.storybook/preview-head.html
@@ -1,3 +1,9 @@
 <script>
   window.global = window;
 </script>
+
+<style>
+  :root {
+    font-family: sans-serif;
+  }
+</style>

--- a/src/renderer/src/stories/Search.js
+++ b/src/renderer/src/stories/Search.js
@@ -56,7 +56,10 @@ export class Search extends LitElement {
 
             .category {
                 padding: 10px 25px;
-                background: #f2f2f2;
+                background: gainsboro;
+                border-top: 1px solid gray;
+                border-bottom: 1px solid gray;
+                font-size: 90%;
                 font-weight: bold;
                 position: sticky;
                 top: 0;

--- a/src/renderer/src/stories/Search.js
+++ b/src/renderer/src/stories/Search.js
@@ -3,7 +3,7 @@ import { LitElement, html, css } from "lit";
 import tippy from "tippy.js";
 
 export class Search extends LitElement {
-    constructor({ options, showAllWhenEmpty, disabledLabel } = {}) {
+    constructor({ options, showAllWhenEmpty = true, disabledLabel } = {}) {
         super();
         this.options = options;
         this.showAllWhenEmpty = showAllWhenEmpty;
@@ -220,7 +220,7 @@ export class Search extends LitElement {
                         return;
                     }
 
-                    return el;
+                    return li;
                 })
                 .filter((el) => el);
 

--- a/src/renderer/src/stories/Search.stories.js
+++ b/src/renderer/src/stories/Search.stories.js
@@ -2,7 +2,7 @@ import { Search } from "./Search";
 
 // More on how to set up stories at: https://storybook.js.org/docs/7.0/web-components/writing-stories/introduction
 export default {
-    title: "Example/Search",
+    title: "Components/Search",
     // tags: ['autodocs'],
 };
 
@@ -18,6 +18,28 @@ Default.args = {
         },
         {
             label: "DeepLabCut",
+            keywords: ["DLC", "tracking", "pose estimation"],
+        },
+    ],
+};
+
+export const Categories = Template.bind({});
+Categories.args = {
+    disabledLabel: "Interface not supported",
+    options: [
+        {
+            label: "SpikeGLXConverter",
+            category: 'Converter',
+            keywords: ["extracellular electrophysiology", "voltage", "recording", "neuropixels"],
+        },
+        {
+            label: "SpikeGLXRecording",
+            category: 'Interface',
+            keywords: ["extracellular electrophysiology", "voltage", "recording", "neuropixels"],
+        },
+        {
+            label: "DeepLabCut",
+            category: 'Interface',
             keywords: ["DLC", "tracking", "pose estimation"],
         },
     ],

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
@@ -45,7 +45,6 @@ export class GuidedStructurePage extends Page {
     };
 
     search = new Search({
-        showAllWhenEmpty: true,
         disabledLabel: "Not supported",
     });
 


### PR DESCRIPTION
Addresses (ii) discussed in #467

Since these headers are simple markers less important than the interfaces / converters themselves, I opted for _smaller_ text while boosting the contrast in different ways beyond the list items.

## Before
<img width="686" alt="Screenshot 2023-10-23 at 9 45 54 AM" src="https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/a411d4e4-ffbe-4acc-a903-ad5f2b8452c5">

## After
<img width="689" alt="Screenshot 2023-10-23 at 9 45 36 AM" src="https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/06b92fcf-7a69-4c88-bd4b-3aea0be01885">
