### PR TITLE
Update Contacts and Docs Page

### DIFF
--- a/src/renderer/assets/css/main.css
+++ b/src/renderer/assets/css/main.css
@@ -1728,14 +1728,9 @@ details[open] > summary::before {
 }
 
 .documentation-lottie_style {
-    --lottie-animation-container-width: 400px;
-    --lottie-animation-container-height: 400px;
-    --lottie-animation-container-background-color: transparent;
-    width: var(--lottie-animation-container-width);
-    height: var(--lottie-animation-container-height);
-    background-color: var(--lottie-animation-container-background-color);
+    width: 100%;
+    height: 100%;
     overflow: hidden;
-    margin: 0px !important;
 }
 
 .api_key-btn {

--- a/src/renderer/src/stories/pages/contact-us/Contact.js
+++ b/src/renderer/src/stories/pages/contact-us/Contact.js
@@ -21,27 +21,27 @@ export class ContactPage extends Page {
 
     render() {
         return html`
-            <div class="documentation_container">
-                <div class="document_container">
-                    <div class="doc_container">
-                        <div class="dc_con">
-                            <div class="document-content">
-                                <div id="contact-us-lottie" class="documentation-lottie_style"></div>
-                            </div>
-                            <div class="docu-content-container">
-                                <h2 class="document_text">
-                                    If you encounter any issues or have requests for new features, please create a new
-                                    <a
-                                        target="_blank"
-                                        href="https://github.com/NeurodataWithoutBorders/nwb-guide/issues/new/choose"
-                                        >ticket on our GitHub page</a
-                                    >.
-                                </h2>
-                            </div>
-                        </div>
+        <div class="documentation_container">
+        <div class="document_container">
+            <div class="doc_container">
+                <div class="dc_con">
+                    <div class="document-content">
+                        <div id="contact-us-lottie" class="documentation-lottie_style"></div>
+                    </div>
+                    <div class="docu-content-container">
+                        <h2 class="document_text">
+                            If you encounter any issues or have requests for new features, please create a new
+                            <a
+                                target="_blank"
+                                href="https://github.com/NeurodataWithoutBorders/nwb-guide/issues/new/choose"
+                                >ticket on our GitHub page</a
+                            >.
+                        </h2>
                     </div>
                 </div>
             </div>
+        </div>
+    </div>
         `;
     }
 }

--- a/src/renderer/src/stories/pages/contact-us/Contact.js
+++ b/src/renderer/src/stories/pages/contact-us/Contact.js
@@ -21,27 +21,27 @@ export class ContactPage extends Page {
 
     render() {
         return html`
-        <div class="documentation_container">
-        <div class="document_container">
-            <div class="doc_container">
-                <div class="dc_con">
-                    <div class="document-content">
-                        <div id="contact-us-lottie" class="documentation-lottie_style"></div>
-                    </div>
-                    <div class="docu-content-container">
-                        <h2 class="document_text">
-                            If you encounter any issues or have requests for new features, please create a new
-                            <a
-                                target="_blank"
-                                href="https://github.com/NeurodataWithoutBorders/nwb-guide/issues/new/choose"
-                                >ticket on our GitHub page</a
-                            >.
-                        </h2>
+            <div class="documentation_container">
+                <div class="document_container">
+                    <div class="doc_container">
+                        <div class="dc_con">
+                            <div class="document-content">
+                                <div id="contact-us-lottie" class="documentation-lottie_style"></div>
+                            </div>
+                            <div class="docu-content-container">
+                                <h2 class="document_text">
+                                    If you encounter any issues or have requests for new features, please create a new
+                                    <a
+                                        target="_blank"
+                                        href="https://github.com/NeurodataWithoutBorders/nwb-guide/issues/new/choose"
+                                        >ticket on our GitHub page</a
+                                    >.
+                                </h2>
+                            </div>
+                        </div>
                     </div>
                 </div>
             </div>
-        </div>
-    </div>
         `;
     }
 }

--- a/src/renderer/src/stories/pages/documentation/Documentation.js
+++ b/src/renderer/src/stories/pages/documentation/Documentation.js
@@ -4,6 +4,8 @@ import { Page } from "../Page.js";
 
 import { startLottie } from "../../../dependencies/globals.js";
 
+import { Button } from "../../Button.js";
+
 export class DocumentationPage extends Page {
     header = {
         title: "Documentation",
@@ -28,9 +30,16 @@ export class DocumentationPage extends Page {
                         <div class="dc_con">
                             <div class="document-content">
                                 <div id="documentation-lottie" class="documentation-lottie_style"></div>
+                                ${new Button({
+                                    label: "NWB GUIDE Documentation",
+                                    onClick: () => {
+                                        window.open("https://nwb-guide.readthedocs.io/en/latest/");
+                                    },
+                                })}
                             </div>
                             <div class="docu-content-container">
-                                <h2 class="document_text">Documentation for NWB GUIDE is in development.</h2>
+                        
+                                <h3 style="padding: 0; margin-top: 25px;">Additional Resources</h3>
                                 <p>
                                     Conversion to NWB is powered by
                                     <a target="_blank" href="https://neuroconv.readthedocs.io/">NeuroConv</a>.
@@ -59,27 +68,15 @@ export class DocumentationPage extends Page {
                                     >.
                                 </p>
 
+                                <h3 style="padding: 0; margin-top: 25px;">Acknowledgments</h3>
                                 <p>
-                                    NWB GUIDE is an open-source project developed by CatalystNeuro (Cody Baker, Garrett
-                                    Flynn, Ben Dichter) and Lawrence Berkeley National Laboratory (Ryan Ly, Oliver
-                                    Ruebel) and generously supported by
-                                    <a target="_blank" href="https://www.kavlifoundation.org/">The Kavli Foundation</a>.
+                                    <small>
+                                        NWB GUIDE is an open-source project developed by CatalystNeuro (Cody Baker, Garrett
+                                        Flynn, Ben Dichter) and Lawrence Berkeley National Laboratory (Ryan Ly, Oliver
+                                        Ruebel) and generously supported by
+                                        <a target="_blank" href="https://www.kavlifoundation.org/">The Kavli Foundation</a>.
+                                    </small>
                                 </p>
-
-                                <!--
-                                    <div class="button_container_contact">
-                                        <button
-                                            id="doc-btn"
-                                            class="view_doc_button sodaVideo-button"
-                                            style="margin-top: 1rem"
-                                            @click="${() => {
-                                    window.open("https://neuroconv.readthedocs.io/en/main/");
-                                }}"
-                                        >
-                                            View the NeuroConv Documentation
-                                        </button>
-                                    </div>
-                                    -->
                             </div>
                         </div>
                     </div>

--- a/src/renderer/src/stories/pages/documentation/Documentation.js
+++ b/src/renderer/src/stories/pages/documentation/Documentation.js
@@ -38,7 +38,6 @@ export class DocumentationPage extends Page {
                                 })}
                             </div>
                             <div class="docu-content-container">
-                        
                                 <h3 style="padding: 0; margin-top: 25px;">Additional Resources</h3>
                                 <p>
                                     Conversion to NWB is powered by
@@ -71,10 +70,12 @@ export class DocumentationPage extends Page {
                                 <h3 style="padding: 0; margin-top: 25px;">Acknowledgments</h3>
                                 <p>
                                     <small>
-                                        NWB GUIDE is an open-source project developed by CatalystNeuro (Cody Baker, Garrett
-                                        Flynn, Ben Dichter) and Lawrence Berkeley National Laboratory (Ryan Ly, Oliver
-                                        Ruebel) and generously supported by
-                                        <a target="_blank" href="https://www.kavlifoundation.org/">The Kavli Foundation</a>.
+                                        NWB GUIDE is an open-source project developed by CatalystNeuro (Cody Baker,
+                                        Garrett Flynn, Ben Dichter) and Lawrence Berkeley National Laboratory (Ryan Ly,
+                                        Oliver Ruebel) and generously supported by
+                                        <a target="_blank" href="https://www.kavlifoundation.org/"
+                                            >The Kavli Foundation</a
+                                        >.
                                     </small>
                                 </p>
                             </div>


### PR DESCRIPTION
This PR makes the styling on the Documentation and Contact pages similar,  adds a link to the Read the Docs on the Documentation page, and organizes the Documentation page content with headers.