### PR TITLE
Validate on input delay

### DIFF
--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -120,13 +120,36 @@ export class JSONSchemaInput extends LitElement {
 
     getElement = () => this.shadowRoot.querySelector(".schema-input");
 
-    #updateData = (path, value) => {
-        this.onUpdate ? this.onUpdate(value) : this.form ? this.form.updateData(path, value) : "";
+
+    #activateTimeoutValidation = (name, el, path) => {
+        this.#clearTimeoutValidation()
+        this.#validationTimeout = setTimeout(() => {
+            this.onValidate ? this.onValidate() : this.form ? this.form.triggerValidation(name, el, path) : "";
+        }, 1000)
+    }
+
+    #clearTimeoutValidation = () => {
+        if (this.#validationTimeout) clearTimeout(this.#validationTimeout);
+    }
+
+    #validationTimeout = null;
+    #updateData = (fullPath, value) => {
+
+        this.onUpdate ? this.onUpdate(value) : this.form ? this.form.updateData(fullPath, value) : "";
+
+        const path = [...fullPath]
+        const name = path.splice(-1)[0]
+
         this.value = value; // Update the latest value
+
+        this.#activateTimeoutValidation(name, this.getElement(), path)
+
     };
 
-    #triggerValidation = (name, el, path) =>
-        this.onValidate ? this.onValidate() : this.form ? this.form.triggerValidation(name, el, path) : "";
+    #triggerValidation = (name, el, path) => {
+        this.#clearTimeoutValidation()
+        return this.onValidate ? this.onValidate() : this.form ? this.form.triggerValidation(name, el, path) : "";
+    }
 
     updated() {
         const el = this.getElement();
@@ -297,7 +320,10 @@ export class JSONSchemaInput extends LitElement {
             return html`
                 <select
                     class="guided--input schema-input"
-                    @input=${(ev) => this.#updateData(fullPath, info.enum[ev.target.value])}
+                    @input=${(ev) => {
+                        this.#updateData(fullPath, info.enum[ev.target.value])
+                        this.#activateTimeoutValidation(name, ev.target, path)
+                    }}
                     @change=${(ev) => validateOnChange && this.#triggerValidation(name, ev.target, path)}
                 >
                     <option disabled selected value>${info.placeholder ?? "Select an option"}</option>

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -120,36 +120,33 @@ export class JSONSchemaInput extends LitElement {
 
     getElement = () => this.shadowRoot.querySelector(".schema-input");
 
-
     #activateTimeoutValidation = (name, el, path) => {
-        this.#clearTimeoutValidation()
+        this.#clearTimeoutValidation();
         this.#validationTimeout = setTimeout(() => {
             this.onValidate ? this.onValidate() : this.form ? this.form.triggerValidation(name, el, path) : "";
-        }, 1000)
-    }
+        }, 1000);
+    };
 
     #clearTimeoutValidation = () => {
         if (this.#validationTimeout) clearTimeout(this.#validationTimeout);
-    }
+    };
 
     #validationTimeout = null;
     #updateData = (fullPath, value) => {
-
         this.onUpdate ? this.onUpdate(value) : this.form ? this.form.updateData(fullPath, value) : "";
 
-        const path = [...fullPath]
-        const name = path.splice(-1)[0]
+        const path = [...fullPath];
+        const name = path.splice(-1)[0];
 
         this.value = value; // Update the latest value
 
-        this.#activateTimeoutValidation(name, this.getElement(), path)
-
+        this.#activateTimeoutValidation(name, this.getElement(), path);
     };
 
     #triggerValidation = (name, el, path) => {
-        this.#clearTimeoutValidation()
+        this.#clearTimeoutValidation();
         return this.onValidate ? this.onValidate() : this.form ? this.form.triggerValidation(name, el, path) : "";
-    }
+    };
 
     updated() {
         const el = this.getElement();
@@ -321,8 +318,8 @@ export class JSONSchemaInput extends LitElement {
                 <select
                     class="guided--input schema-input"
                     @input=${(ev) => {
-                        this.#updateData(fullPath, info.enum[ev.target.value])
-                        this.#activateTimeoutValidation(name, ev.target, path)
+                        this.#updateData(fullPath, info.enum[ev.target.value]);
+                        this.#activateTimeoutValidation(name, ev.target, path);
                     }}
                     @change=${(ev) => validateOnChange && this.#triggerValidation(name, ev.target, path)}
                 >


### PR DESCRIPTION
This PR allows forms to validate on input delay (currently 1s) instead of waiting for the user to click off the input—as some don't realize to do this.

## Alpha Test Issues
1. Would be nice to be able to get feedback on the validity of your metadata before clicking out of the input but still when you’re done typing (e.g. if the user doesn’t change their input in 2s)