### PR TITLE
Update data flow

### DIFF
--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -178,8 +178,8 @@ export class JSONSchemaForm extends LitElement {
     #updateRendered = (force) =>
         force || this.#rendered === true
             ? (this.#rendered = new Promise(
-                (resolve) => (this.#toggleRendered = () => resolve((this.#rendered = true)))
-            ))
+                  (resolve) => (this.#toggleRendered = () => resolve((this.#rendered = true)))
+              ))
             : this.#rendered;
 
     resolved = {}; // Keep track of actual resolved values—not just what the user provides as results
@@ -440,8 +440,8 @@ export class JSONSchemaForm extends LitElement {
             <div
                 id=${localPath.join("-")}
                 class="form-section ${isRequired || isConditional ? "required" : ""} ${isConditional
-                ? "conditional"
-                : ""}"
+                    ? "conditional"
+                    : ""}"
             >
                 <label class="guided--form-label">${info.title ?? header(name)}</label>
                 ${interactiveInput}
@@ -490,9 +490,9 @@ export class JSONSchemaForm extends LitElement {
     };
 
     // Checks missing required properties and throws an error if any are found
-    onInvalid = () => { };
-    onLoaded = () => { };
-    onUpdate = () => { };
+    onInvalid = () => {};
+    onLoaded = () => {};
+    onUpdate = () => {};
 
     #deleteExtraneousResults = (results, schema) => {
         for (let name in results) {
@@ -543,10 +543,10 @@ export class JSONSchemaForm extends LitElement {
         return flattenRecursedValues(res); // Flatten on the last pass
     };
 
-    validateOnChange = () => { };
-    onStatusChange = () => { };
-    onThrow = () => { };
-    renderTable = () => { };
+    validateOnChange = () => {};
+    onStatusChange = () => {};
+    onThrow = () => {};
+    renderTable = () => {};
 
     #getLink = (args) => {
         if (typeof args === "string") args = args.split("-");
@@ -633,15 +633,11 @@ export class JSONSchemaForm extends LitElement {
                     }, externalPath);
                 }
             }
-        }
-
-        else {
-
+        } else {
             // For non-links, throw a basic requirement error if the property is required
             if (!errors.length && isRequired && !parent[name]) {
-
                 // Skip simple required checks in loose mode
-                if (this.requirementMode !== 'loose') {
+                if (this.requirementMode !== "loose") {
                     const schema = this.getSchema(localPath);
                     errors.push({
                         message: `${schema.title ?? header(name)} is a required property.`,
@@ -691,7 +687,6 @@ export class JSONSchemaForm extends LitElement {
 
             return true;
         } else {
-
             // Add new invalid classes and errors
             input.classList.add("invalid");
 

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -119,7 +119,7 @@ export class JSONSchemaInput extends LitElement {
         this.#triggerValidation(name, path);
         this.#updateData(fullPath, value);
 
-        const el = this.getElement()
+        const el = this.getElement();
         if (el.type === "checkbox") el.checked = value;
         else el.value = value;
 

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -118,6 +118,8 @@ export class JSONSchemaInput extends LitElement {
 
         this.#triggerValidation(name, path);
         this.#updateData(fullPath, value);
+        
+        const el = this.getElement()
         if (el.type === "checkbox") el.checked = value;
         else el.value = value;
 

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -30,6 +30,11 @@ export class JSONSchemaInput extends LitElement {
                 display: block;
             }
 
+            :host(.invalid) .guided--input {
+                background: rgb(255, 229, 228) !important;
+            }
+          
+
             .guided--input {
                 width: 100%;
                 border-radius: 4px;
@@ -109,8 +114,8 @@ export class JSONSchemaInput extends LitElement {
         const { path: fullPath } = this;
         const path = typeof fullPath === "string" ? fullPath.split("-") : [...fullPath];
         const name = path.splice(-1)[0];
-        const el = this.getElement();
-        this.#triggerValidation(name, el, path);
+
+        this.#triggerValidation(name, path);
         this.#updateData(fullPath, value);
         if (el.type === "checkbox") el.checked = value;
         else el.value = value;
@@ -125,8 +130,8 @@ export class JSONSchemaInput extends LitElement {
         this.value = value; // Update the latest value
     };
 
-    #triggerValidation = (name, el, path) =>
-        this.onValidate ? this.onValidate() : this.form ? this.form.triggerValidation(name, el, path) : "";
+    #triggerValidation = (name, path) =>
+        this.onValidate ? this.onValidate() : this.form ? this.form.triggerValidation(name, path) : "";
 
     updated() {
         const el = this.getElement();
@@ -169,7 +174,7 @@ export class JSONSchemaInput extends LitElement {
                 type: format,
                 value: this.value,
                 onSelect: (filePath) => this.#updateData(fullPath, filePath),
-                onChange: (filePath) => validateOnChange && this.#triggerValidation(name, el, path),
+                onChange: (filePath) => validateOnChange && this.#triggerValidation(name, path),
                 onThrow: (...args) => this.#onThrow(...args),
                 dialogOptions: this.form?.dialogOptions,
                 dialogType: this.form?.dialogType,
@@ -270,7 +275,7 @@ export class JSONSchemaInput extends LitElement {
                     : [],
                 onChange: async () => {
                     this.#updateData(fullPath, list.items.length ? list.items.map((o) => o.value) : undefined);
-                    if (validateOnChange) await this.#triggerValidation(name, list, path);
+                    if (validateOnChange) await this.#triggerValidation(name, path);
                 },
             });
 
@@ -285,7 +290,7 @@ export class JSONSchemaInput extends LitElement {
             return html`
                 <div
                     class="schema-input"
-                    @change=${() => validateOnChange && this.#triggerValidation(name, list, path)}
+                    @change=${() => validateOnChange && this.#triggerValidation(name, path)}
                 >
                     ${list} ${addButton}
                 </div>
@@ -298,7 +303,7 @@ export class JSONSchemaInput extends LitElement {
                 <select
                     class="guided--input schema-input"
                     @input=${(ev) => this.#updateData(fullPath, info.enum[ev.target.value])}
-                    @change=${(ev) => validateOnChange && this.#triggerValidation(name, ev.target, path)}
+                    @change=${(ev) => validateOnChange && this.#triggerValidation(name, path)}
                 >
                     <option disabled selected value>${info.placeholder ?? "Select an option"}</option>
                     ${info.enum.map(
@@ -312,7 +317,7 @@ export class JSONSchemaInput extends LitElement {
                 class="schema-input"
                 @input=${(ev) => this.#updateData(fullPath, ev.target.checked)}
                 ?checked=${this.value ?? false}
-                @change=${(ev) => validateOnChange && this.#triggerValidation(name, ev.target, path)}
+                @change=${(ev) => validateOnChange && this.#triggerValidation(name, path)}
             />`;
         } else if (info.type === "string" || info.type === "number") {
             const fileSystemFormat = isFilesystemSelector(name, info.format);
@@ -329,7 +334,7 @@ export class JSONSchemaInput extends LitElement {
                     @input=${(ev) => {
                         this.#updateData(fullPath, ev.target.value);
                     }}
-                    @change=${(ev) => validateOnChange && this.#triggerValidation(name, ev.target, path)}
+                    @change=${(ev) => validateOnChange && this.#triggerValidation(name, path)}
                 ></textarea>`;
             // Handle other string formats
             else {
@@ -349,7 +354,7 @@ export class JSONSchemaInput extends LitElement {
                                 fullPath,
                                 info.type === "number" ? parseFloat(ev.target.value) : ev.target.value
                             )}
-                        @change=${(ev) => validateOnChange && this.#triggerValidation(name, ev.target, path)}
+                        @change=${(ev) => validateOnChange && this.#triggerValidation(name, path)}
                     />
                 `;
             }

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -110,9 +110,8 @@ export class JSONSchemaInput extends LitElement {
     // onValidate = () => {}
 
     updateData(value) {
-
         if (this.value === value) return false;
-        
+
         const { path: fullPath } = this;
         const path = typeof fullPath === "string" ? fullPath.split("-") : [...fullPath];
         const name = path.splice(-1)[0];

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -110,6 +110,9 @@ export class JSONSchemaInput extends LitElement {
     // onValidate = () => {}
 
     updateData(value) {
+
+        if (this.value === value) return false;
+        
         const { path: fullPath } = this;
         const path = typeof fullPath === "string" ? fullPath.split("-") : [...fullPath];
         const name = path.splice(-1)[0];

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -33,7 +33,6 @@ export class JSONSchemaInput extends LitElement {
             :host(.invalid) .guided--input {
                 background: rgb(255, 229, 228) !important;
             }
-          
 
             .guided--input {
                 width: 100%;
@@ -288,10 +287,7 @@ export class JSONSchemaInput extends LitElement {
             });
 
             return html`
-                <div
-                    class="schema-input"
-                    @change=${() => validateOnChange && this.#triggerValidation(name, path)}
-                >
+                <div class="schema-input" @change=${() => validateOnChange && this.#triggerValidation(name, path)}>
                     ${list} ${addButton}
                 </div>
             `;

--- a/src/renderer/src/stories/Main.js
+++ b/src/renderer/src/stories/Main.js
@@ -105,7 +105,6 @@ export class Main extends LitElement {
 
             // Default Capsules Behavior
             const section = sections[info.section];
-            console.log("Sections", section, sections);
             if (section) {
                 if (capsules === true || !("capsules" in page)) {
                     let pages = Object.values(section.pages);

--- a/src/renderer/src/stories/OptionalSection.js
+++ b/src/renderer/src/stories/OptionalSection.js
@@ -11,11 +11,12 @@ export class OptionalSection extends LitElement {
 
             h2 {
                 margin: 0;
-                margin-bottom: 15px;
+                margin-bottom: 10px;
             }
 
             .optional-section__toggle {
-                padding-bottom: 20px;
+                margin: 10px 0px;
+                margin-bottom: 20px;
             }
 
             .optional-section__content {

--- a/src/renderer/src/stories/OptionalSection.js
+++ b/src/renderer/src/stories/OptionalSection.js
@@ -24,12 +24,6 @@ export class OptionalSection extends LitElement {
         `;
     }
 
-    static get properties() {
-        return {
-            state: { type: Boolean, reflect: true },
-        };
-    }
-
     get hidden() {
         return this.shadowRoot.querySelector(".optional-section__content").hidden;
     }

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -118,15 +118,15 @@ export class GuidedPathExpansionPage extends Page {
 
         // Force single subject/session
         if (hidden) {
+            const existingMetadata =
+                globalState.results?.[this.altInfo.subject_id]?.[this.altInfo.session_id]?.metadata;
 
-            const existingMetadata = globalState.results?.[this.altInfo.subject_id]?.[this.altInfo.session_id]?.metadata;
-
-            const existingSourceData = globalState.results?.[this.altInfo.subject_id]?.[this.altInfo.session_id]?.source_data;
+            const existingSourceData =
+                globalState.results?.[this.altInfo.subject_id]?.[this.altInfo.session_id]?.source_data;
 
             const source_data = {};
             for (let key in globalState.interfaces) source_data[key] = existingSourceData[key] ?? {};
 
- 
             globalState.results = {
                 [this.altInfo.subject_id]: {
                     [this.altInfo.session_id]: {
@@ -150,7 +150,7 @@ export class GuidedPathExpansionPage extends Page {
         else if (!hidden && hidden !== undefined) {
             const structure = globalState.structure.results;
 
-            await this.form.validate()
+            await this.form.validate();
 
             const finalStructure = {};
             for (let key in structure) {
@@ -190,11 +190,9 @@ export class GuidedPathExpansionPage extends Page {
                                 if (!sesRef.source_data[name]) delete sesRef.source_data[name]; // Delete removed interfaces
                             }
                         }
-
                     }
 
-                    if (Object.keys(globalResults[sub]).length === 0) delete globalResults[sub] // Delete empty subjects
-
+                    if (Object.keys(globalResults[sub]).length === 0) delete globalResults[sub]; // Delete empty subjects
                 }
             }
         }

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -177,14 +177,16 @@ export class GuidedPathExpansionPage extends Page {
             // Save an overall results object organized by subject and session
             merge({ results }, globalState);
 
-            for (let sub in globalState.results) {
-                const subRef = globalState.results[sub];
-                if (!globalState.results[sub]) delete globalState.results[sub]; // Delete removed subjects
+            const globalResults = globalState.results
+
+            for (let sub in globalResults) {
+                const subRef = results[sub];
+                if (!results[sub]) delete globalResults[sub]; // Delete removed subjects
                 else {
                     for (let ses in subRef) {
-                        const sesRef = globalState.results[sub];
+                        const sesRef = results[sub][ses];
 
-                        if (!sesRef) delete globalState.results[sub][ses]; // Delete removed sessions
+                        if (!sesRef) delete globalResults[sub][ses]; // Delete removed sessions
                         else {
                             for (let name in sesRef.source_data) {
                                 if (!sesRef.source_data[name]) delete sesRef.source_data[name]; // Delete removed interfaces

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -277,15 +277,11 @@ export class GuidedPathExpansionPage extends Page {
         const form = (this.form = new JSONSchemaForm({
             ...structureState,
             onThrow,
+            requirementMode: "loose",
             validateOnChange: async (name, parent, parentPath) => {
                 const value = parent[name];
                 if (fs) {
                     if (name === "base_directory") {
-                        // for (const f of getFiles(value)) {
-                        //     console.log(f);
-                        //   }
-                        // const res = getFiles(value);
-
                         const input = form.getInput([...parentPath, "format_string_path"]);
                         input.updateData(input.value);
                     } else if (name === "format_string_path") {
@@ -316,8 +312,6 @@ export class GuidedPathExpansionPage extends Page {
                                 resolved.push(path);
                             }
                         }
-
-                        console.log("Metadata Results for", interfaceName, results);
 
                         return [
                             {

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -183,7 +183,7 @@ export class GuidedPathExpansionPage extends Page {
                 const subRef = results[sub];
                 if (!results[sub]) delete globalResults[sub]; // Delete removed subjects
                 else {
-                    for (let ses in subRef) {
+                    for (let ses in globalResults[sub]) {
                         const sesRef = results[sub][ses];
 
                         if (!sesRef) delete globalResults[sub][ses]; // Delete removed sessions


### PR DESCRIPTION
This PR ensures proper data flow in the following conditions:
 1. Invalid inputs into Global Metadata fields
 2. Exiting and starting a new conversion after visiting the Locata Data page
 3. Removing a subject / session / interface after filling out information on the Source Data (and later) page.
 4. Wanting to use path expansion for one interface but not another
 5. Deciding to re-run path expansion while keeping data for subjects / sessions that aren't found the second time around

Specifically for (5), I've added a new input to the top of the Locate Data page that allows users to decide to keep / clear data that already exists.

## Alpha Test Issues
1. After Locate Data, extra interface source data remains in the data structure.
