### PR TITLE
Global metadata on demand

### DIFF
--- a/schemas/base-metadata.schema.ts
+++ b/schemas/base-metadata.schema.ts
@@ -4,3 +4,30 @@ baseMetadataSchema.properties.Subject.properties.weight.unit = 'kg' // Add unit 
 
 
 export default baseMetadataSchema
+
+
+export const instanceSpecificFields = {
+    Subject: ["weight", "subject_id", "age", "date_of_birth", "age__reference"],
+    NWBFile: [
+        "session_id",
+        "session_start_time",
+        "identifier",
+        "data_collection",
+        "notes",
+        "pharmacolocy",
+        "session_description",
+        "slices",
+        "source_script",
+        "source_script_file_name",
+    ],
+};
+
+
+const globalSchema = structuredClone(baseMetadataSchema);
+Object.entries(globalSchema.properties).forEach(([globalProp, schema]) => {
+    instanceSpecificFields[globalProp]?.forEach((prop) =>  delete schema.properties[prop]);
+});
+
+export {
+    globalSchema
+}

--- a/schemas/json/base_metadata_schema.json
+++ b/schemas/json/base_metadata_schema.json
@@ -1,8 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "$id": "base_metafile.schema.json",
-  "title": "Base schema for the metafile",
-  "description": "Base schema for the metafile",
   "version": "0.1.0",
   "type": "object",
   "required": ["NWBFile"],

--- a/src/renderer/src/stories/BasicTable.js
+++ b/src/renderer/src/stories/BasicTable.js
@@ -154,7 +154,7 @@ export class BasicTable extends LitElement {
             } else
                 value =
                     (hasRow ? this.data[row][col] : undefined) ??
-                    // this.template[col] ??
+                    // this.globals[col] ??
                     this.schema.properties[col].default ??
                     "";
             return value;

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -168,6 +168,7 @@ export class JSONSchemaForm extends LitElement {
             dialogType: { type: String, reflect: false },
             dialogOptions: { type: Object, reflect: false },
             requirementMode: { type: String, reflect: true },
+            globals: { type: Object, reflect: false },
         };
     }
 

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -110,9 +110,11 @@ export class JSONSchemaInput extends LitElement {
         const path = typeof fullPath === "string" ? fullPath.split("-") : [...fullPath];
         const name = path.splice(-1)[0];
         const el = this.getElement();
+
         this.#triggerValidation(name, el, path);
         this.#updateData(fullPath, value);
         if (el.type === "checkbox") el.checked = value;
+        else if (el.classList.contains('list')) el.children[0].items = value ? value.map((value) => { return { value } }) : []
         else el.value = value;
 
         return true;
@@ -284,7 +286,7 @@ export class JSONSchemaInput extends LitElement {
 
             return html`
                 <div
-                    class="schema-input"
+                    class="schema-input list"
                     @change=${() => validateOnChange && this.#triggerValidation(name, list, path)}
                 >
                     ${list} ${addButton}

--- a/src/renderer/src/stories/SimpleTable.js
+++ b/src/renderer/src/stories/SimpleTable.js
@@ -163,7 +163,7 @@ export class SimpleTable extends LitElement {
     constructor({
         schema,
         data,
-        template,
+        globals,
         keyColumn,
         validateOnChange,
         validateEmptyCells,
@@ -178,7 +178,7 @@ export class SimpleTable extends LitElement {
         this.schema = schema ?? {};
         this.data = data ?? [];
         this.keyColumn = keyColumn;
-        this.template = template ?? {};
+        this.globals = globals ?? {};
         this.validateEmptyCells = validateEmptyCells ?? true;
         this.deferLoading = deferLoading ?? false;
         this.maxHeight = maxHeight ?? "";
@@ -334,7 +334,7 @@ export class SimpleTable extends LitElement {
             } else
                 value =
                     (hasRow ? this.data[row][col] : undefined) ??
-                    this.template[col] ??
+                    this.globals[col] ??
                     this.schema.properties[col].default ??
                     "";
             return value;
@@ -631,7 +631,7 @@ export class SimpleTable extends LitElement {
         }
         // Update data on passed object
         else {
-            if (value == undefined || value === "") delete target[rowName][header];
+            if (value == undefined || value === "") target[rowName][header] = undefined;
             else target[rowName][header] = value;
         }
 

--- a/src/renderer/src/stories/Table.js
+++ b/src/renderer/src/stories/Table.js
@@ -60,10 +60,11 @@ export class Table extends LitElement {
     constructor({
         schema,
         data,
-        template,
+        globals,
         keyColumn,
         validateOnChange,
         onUpdate,
+        onOverride,
         validateEmptyCells,
         onStatusChange,
         contextMenu,
@@ -72,11 +73,12 @@ export class Table extends LitElement {
         this.schema = schema ?? {};
         this.data = data ?? [];
         this.keyColumn = keyColumn;
-        this.template = template ?? {};
+        this.globals = globals ?? {};
         this.validateEmptyCells = validateEmptyCells ?? true;
         this.contextMenu = contextMenu ?? {};
 
         if (onUpdate) this.onUpdate = onUpdate;
+        if (onOverride) this.onOverride = onOverride;
         if (validateOnChange) this.validateOnChange = validateOnChange;
         if (onStatusChange) this.onStatusChange = onStatusChange;
 
@@ -92,6 +94,7 @@ export class Table extends LitElement {
     static get properties() {
         return {
             data: { type: Object, reflect: true },
+            globals: { type: Object, reflect: true },
         };
     }
 
@@ -109,7 +112,7 @@ export class Table extends LitElement {
             } else
                 value =
                     (hasRow ? this.data[row][col] : undefined) ??
-                    this.template[col] ??
+                    this.globals[col] ??
                     // this.schema.properties[col].default ??
                     "";
             return value;
@@ -132,7 +135,7 @@ export class Table extends LitElement {
         if (!message) {
             const errors = this.querySelectorAll("[error]");
             const len = errors.length;
-            if (len === 1) message = errors[0].title || "Error found";
+            if (len === 1) message = errors[0].getAttribute('data-message') || "Error found";
             else if (len) message = `${len} errors exist on this table.`;
         }
 
@@ -148,6 +151,7 @@ export class Table extends LitElement {
     status;
     onStatusChange = () => {};
     onUpdate = () => {};
+    onOverride = () => {};
 
     updated() {
         const div = (this.shadowRoot ?? this).querySelector("div");
@@ -326,6 +330,8 @@ export class Table extends LitElement {
             descriptionEl.innerText = desc;
         }
 
+        if (this.table) this.table.destroy();
+
         const table = new Handsontable(div, {
             data,
             // rowHeaders: rowHeaders.map(v => `sub-${v}`),
@@ -371,6 +377,8 @@ export class Table extends LitElement {
                 }
             }
 
+            const isUserUpdate = initialCellsToUpdate <= validated
+
             // Transfer data to object
             if (header === this.keyColumn) {
                 if (value !== rowName) {
@@ -384,13 +392,22 @@ export class Table extends LitElement {
 
             // Update data on passed object
             else {
-                if (value == undefined || value === "") delete target[rowName][header];
-                else target[rowName][header] = value;
+                const globalValue = this.globals[header];
+
+                if (value == undefined || value === "") {
+                    if (globalValue) {
+                        value = target[rowName][header] = globalValue;
+                        table.setDataAtCell(row, prop, value);
+                        this.onOverride(header, value, rowName)
+                    }
+                    target[rowName][header] = undefined;
+                }
+                else target[rowName][header] = (value === globalValue) ? undefined : value;
             }
 
             validated++;
 
-            if (initialCellsToUpdate < validated) this.onUpdate(rowName, header, value);
+            if (isUserUpdate) this.onUpdate(rowName, header, value);
 
             if (typeof isValid === "function") isValid();
             // }
@@ -437,21 +454,27 @@ export class Table extends LitElement {
         const cell = this.table.getCell(row, prop); // NOTE: Does not resolve unless the cell is rendered...
 
         if (cell) {
-            let title = "";
+            let message = "";
             let theme = "";
             if (warnings.length) {
-                (theme = "warning"), (title = warnings.map((o) => o.message).join("\n"));
+                (theme = "warning"), (message = warnings.map((o) => o.message).join("\n"));
             } else cell.removeAttribute("warning");
 
             if (errors.length) {
-                (theme = "error"), (title = errors.map((o) => o.message).join("\n")); // Class switching handled automatically
+                (theme = "error"), (message = errors.map((o) => o.message).join("\n")); // Class switching handled automatically
             } else cell.removeAttribute("error");
 
             if (theme) cell.setAttribute(theme, "");
 
-            if (cell._tippy) cell._tippy.destroy();
+            if (cell._tippy) {
+                cell._tippy.destroy();
+                cell.removeAttribute('data-message')
+            }
 
-            if (title) tippy(cell, { content: title, theme });
+            if (message) {
+                tippy(cell, { content: message, theme });
+                cell.setAttribute('data-message', message)
+            }
         }
 
         this.#checkStatus(); // Check status after every validation update

--- a/src/renderer/src/stories/forms/GlobalFormModal.ts
+++ b/src/renderer/src/stories/forms/GlobalFormModal.ts
@@ -5,19 +5,25 @@ import { JSONSchemaForm } from "../JSONSchemaForm"
 
 import { onThrow } from "../../errors";
 import { merge } from "../pages/utils.js";
+import { save } from "../../progress/index.js";
+
 
 export function createGlobalFormModal(this: Page, {
     header,
     schema,
     propsToIgnore = [],
     propsToRemove = [],
-    key
+    key,
+    hasInstances = false,
+    validateOnChange
 }: {
     header: string
     schema: any
     propsToIgnore?: string[]
     propsToRemove?: string[]
-    key?: string
+    key?: string,
+    hasInstances?: boolean
+    validateOnChange?: Function
 
 }) {
     const modal = new Modal({
@@ -28,37 +34,39 @@ export function createGlobalFormModal(this: Page, {
 
     const schemaCopy = structuredClone(schema)
 
-    Object.keys(schemaCopy.properties).forEach(i => {
-        const iSchemaProps = schemaCopy.properties[i].properties
-        Object.keys(iSchemaProps).forEach(key => {
-            if (propsToRemove.includes(key)) delete iSchemaProps[key]
-        })
-    })
+    function removeProperties(obj: any, props: string[]) {
+        props.forEach(prop =>  delete obj[prop])
+    }
+
+    if (hasInstances) Object.keys(schemaCopy.properties).forEach(i => removeProperties(schemaCopy.properties[i].properties, propsToRemove))
+    else removeProperties(schemaCopy.properties, propsToRemove)
 
     const form = new JSONSchemaForm({
         requirementMode: "loose",
         schema: schemaCopy,
         emptyMessage: "No properties to edit globally.",
         ignore: propsToIgnore,
-        onUpdate: () => (this.unsavedUpdates = true),
         onThrow,
+        validateOnChange
     })
 
     content.append(form)
 
-    content.style.padding = "0px 25px 25px 25px"
+    content.style.padding = "25px"
 
     const saveButton = new Button({
-        label: "Save",
+        label: "Update",
         primary: true,
         onClick: async () => {
             await form.validate()
             const result = merge(key ?  {[key]: form.results} : form.results, this.info.globalState.project)
-            await this.save()
-            this.forms.forEach(({form}) => {
-                console.log(result)
-                form.globals = structuredClone(key ?  result[key]: result)
-            })
+            await save(this)
+
+            const forms = hasInstances ? this.forms.map(o => o.form) :  this.form ? [ this.form ] : []
+            const tables = hasInstances ? this.tables : this.table ? [ this.table ] : []
+            forms.forEach(form =>form.globals = structuredClone(key ?  result[key]: result))
+            tables.forEach(table => table.globals = structuredClone(key ?  result[key]: result))
+
             modal.open = false
         }
     })

--- a/src/renderer/src/stories/forms/GlobalFormModal.ts
+++ b/src/renderer/src/stories/forms/GlobalFormModal.ts
@@ -1,0 +1,72 @@
+import { Modal } from "../Modal"
+import { Page } from "../pages/Page.js"
+import { Button } from "../Button"
+import { JSONSchemaForm } from "../JSONSchemaForm"
+
+import { onThrow } from "../../errors";
+import { merge } from "../pages/utils.js";
+
+export function createGlobalFormModal(this: Page, {
+    header,
+    schema,
+    propsToIgnore = [],
+    propsToRemove = [],
+    key
+}: {
+    header: string
+    schema: any
+    propsToIgnore?: string[]
+    propsToRemove?: string[]
+    key?: string
+
+}) {
+    const modal = new Modal({
+        header
+    })
+
+    const content = document.createElement("div")
+
+    const schemaCopy = structuredClone(schema)
+
+    Object.keys(schemaCopy.properties).forEach(i => {
+        const iSchemaProps = schemaCopy.properties[i].properties
+        Object.keys(iSchemaProps).forEach(key => {
+            if (propsToRemove.includes(key)) delete iSchemaProps[key]
+        })
+    })
+
+    const form = new JSONSchemaForm({
+        requirementMode: "loose",
+        schema: schemaCopy,
+        emptyMessage: "No properties to edit globally.",
+        ignore: propsToIgnore,
+        onUpdate: () => (this.unsavedUpdates = true),
+        onThrow,
+    })
+
+    content.append(form)
+
+    content.style.padding = "0px 25px 25px 25px"
+
+    const saveButton = new Button({
+        label: "Save",
+        primary: true,
+        onClick: async () => {
+            await form.validate()
+            const result = merge(key ?  {[key]: form.results} : form.results, this.info.globalState.project)
+            await this.save()
+            this.forms.forEach(({form}) => {
+                console.log(result)
+                form.globals = structuredClone(key ?  result[key]: result)
+            })
+            modal.open = false
+        }
+    })
+
+    modal.form = form
+
+    modal.footer = saveButton
+
+    modal.append(content)
+    return modal
+}

--- a/src/renderer/src/stories/pages/Page.js
+++ b/src/renderer/src/stories/pages/Page.js
@@ -2,7 +2,7 @@ import { LitElement, html } from "lit";
 import { openProgressSwal, runConversion } from "./guided-mode/options/utils.js";
 import { get, save } from "../../progress/index.js";
 import { dismissNotification, notify } from "../../dependencies/globals.js";
-import { merge, randomizeElements, mapSessions } from "./utils.js";
+import { randomizeElements, mapSessions } from "./utils.js";
 
 import { ProgressBar } from "../ProgressBar";
 import { resolveResults } from "./guided-mode/data/utils.js";

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -12,6 +12,15 @@ import { onThrow } from "../../../../errors";
 import { merge } from "../../utils.js";
 import { NWBFilePreview } from "../../../preview/NWBFilePreview.js";
 
+const propsToIgnore = [
+    "Ophys", // Always ignore ophys metadata (for now)
+    "Icephys", // Always ignore icephys metadata (for now)
+    "Behavior", // Always ignore behavior metadata (for now)
+    new RegExp("ndx-.+"), // Ignore all ndx extensions
+    "subject_id",
+    "session_id",
+]
+
 const getInfoFromId = (key) => {
     let [subject, session] = key.split("/");
     if (subject.startsWith("sub-")) subject = subject.slice(4);
@@ -110,14 +119,7 @@ export class GuidedMetadataPage extends ManagedPage {
             results,
             globals: aggregateGlobalMetadata,
 
-            ignore: [
-                "Ophys", // Always ignore ophys metadata (for now)
-                "Icephys", // Always ignore icephys metadata (for now)
-                "Behavior", // Always ignore behavior metadata (for now)
-                new RegExp("ndx-.+"), // Ignore all ndx extensions
-                "subject_id",
-                "session_id",
-            ],
+            ignore: propsToIgnore,
 
             conditionalRequirements: [
                 {

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -11,6 +11,7 @@ import { SimpleTable } from "../../../SimpleTable.js";
 import { onThrow } from "../../../../errors";
 import { merge } from "../../utils.js";
 import { NWBFilePreview } from "../../../preview/NWBFilePreview.js";
+import { header } from "../../../forms/utils";
 
 const propsToIgnore = [
     "Ophys", // Always ignore ophys metadata (for now)
@@ -69,6 +70,7 @@ export class GuidedMetadataPage extends ManagedPage {
         },
     };
 
+
     createForm = ({ subject, session, info }) => {
         // const results = createResults({ subject, info }, this.info.globalState);
 
@@ -120,6 +122,9 @@ export class GuidedMetadataPage extends ManagedPage {
             globals: aggregateGlobalMetadata,
 
             ignore: propsToIgnore,
+            onOverride: (name) => {
+                this.notify(`<b>${header(name)}</b> has been overriden with a global value.`, 'warning', 3000)
+            },
 
             conditionalRequirements: [
                 {

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -9,6 +9,7 @@ import { merge } from "../../utils.js";
 import getSourceDataSchema from "../../../../../../../schemas/source-data.schema";
 
 import {  createGlobalFormModal } from '../../../forms/GlobalFormModal'
+import { header } from "../../../forms/utils";
 
 const propsToIgnore = [
     "verbose",
@@ -130,6 +131,9 @@ export class GuidedSourceDataPage extends ManagedPage {
             emptyMessage: "No source data required for this session.",
             ignore: propsToIgnore,
             globals: this.info.globalState.project.SourceData,
+            onOverride: (name) => {
+                this.notify(`<b>${header(name)}</b> has been overriden with a global value.`, 'warning', 3000)
+            },
             // onlyRequired: true,
             onUpdate: () => (this.unsavedUpdates = true),
             onStatusChange: (state) => this.manager.updateState(instanceId, state),
@@ -153,7 +157,8 @@ export class GuidedSourceDataPage extends ManagedPage {
             header: "Edit Global Source Data",
             propsToRemove: [...propsToIgnore, 'folder_path', 'file_path'],
             key: 'SourceData',
-            schema: this.info.globalState.schema.source_data
+            schema: this.info.globalState.schema.source_data,
+            hasInstances: true
         })
         document.body.append(modal)
     }

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -10,6 +10,7 @@ import getSourceDataSchema from "../../../../../../../schemas/source-data.schema
 
 import {  createGlobalFormModal } from '../../../forms/GlobalFormModal'
 import { header } from "../../../forms/utils";
+import { Button } from "../../../Button.js";
 
 const propsToIgnore = [
     "verbose",
@@ -30,8 +31,18 @@ export class GuidedSourceDataPage extends ManagedPage {
     };
 
     header = {
+        controls: [
+            new Button({
+                label: "Edit Global Metadata",
+                onClick: () => {
+                    this.#globalModal.form.results = merge(this.info.globalState.project?.SourceData, {})
+                    this.#globalModal.open = true
+                    
+                },
+            })
+        ],
         subtitle:
-            "Specify the file and folder locations on your local system for each interface, as well as any additional details that might be required",
+            "Specify the file and folder locations on your local system for each interface, as well as any additional details that might be required.",
     };
 
     footer = {
@@ -183,16 +194,6 @@ export class GuidedSourceDataPage extends ManagedPage {
             header: "Sessions",
             // instanceType: 'Session',
             instances,
-            controls: [
-                {
-                    name: "Edit Global Metadata",
-                    onClick: () => {
-                        this.#globalModal.form.results = merge(this.info.globalState.project?.SourceData, {})
-                        this.#globalModal.open = true
-                        
-                    },
-                },
-            ]
             // onAdded: (path) => {
 
             //   let details = this.getDetails(path)

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
@@ -15,6 +15,8 @@ import { InstanceManager } from "../../../InstanceManager.js";
 import { path as nodePath } from "../../../../electron";
 import { getMessageType } from "../../../../validation/index.js";
 
+import { InfoBox } from '../../../InfoBox'
+
 const filter = (list, toFilter) => {
     return list.filter((o) => {
         return Object.entries(toFilter)
@@ -36,7 +38,7 @@ export class GuidedInspectorPage extends Page {
     }
 
     header = {
-        subtitle: `The NWB Inspector has scanned your files for adherence to <a target="_blank" href="https://nwbinspector.readthedocs.io/en/dev/best_practices/best_practices_index.html">best practices</a>`,
+        subtitle: `The NWB Inspector has scanned your files for adherence to <a target="_blank" href="https://nwbinspector.readthedocs.io/en/dev/best_practices/best_practices_index.html">best practices</a>.`,
         controls: () =>
             html`<nwb-button
                 size="small"
@@ -77,7 +79,12 @@ export class GuidedInspectorPage extends Page {
                 })
             )
             .flat();
-        return html` ${until(
+        return html` 
+        ${new InfoBox({
+            header: "How do I fix these suggestions?",
+            content: html`We suggest editing the Global Metadata on the <b>previous page</b> to fix any issues shared across files.`
+        })}
+        ${until(
             (async () => {
                 if (fileArr.length <= 1) {
                     const items =

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
@@ -9,33 +9,15 @@ import projectGlobalSchema from "../../../../../../../schemas/json/project/globa
 import { merge } from "../../utils.js";
 import { schemaToPages } from "../../FormPage.js";
 import { onThrow } from "../../../../errors";
-import baseMetadataSchema from "../../../../../../../schemas/base-metadata.schema";
 
-const changesAcrossSessions = {
-    Subject: ["weight", "subject_id", "age", "date_of_birth", "age__reference"],
-    NWBFile: [
-        "session_id",
-        "session_start_time",
-        "identifier",
-        "data_collection",
-        "notes",
-        "pharmacolocy",
-        "session_description",
-        "slices",
-        "source_script",
-        "source_script_file_name",
-    ],
-};
+import { globalSchema } from "../../../../../../../schemas/base-metadata.schema";
+import { header } from "../../../forms/utils";
+
 
 const projectMetadataSchema = merge(projectGlobalSchema, projectGeneralSchema);
 
-Object.entries(baseMetadataSchema.properties).forEach(([globalProp, v]) => {
-    const info = (projectMetadataSchema.properties[globalProp] = structuredClone(v));
+merge(globalSchema, projectMetadataSchema)
 
-    changesAcrossSessions[globalProp]?.forEach((prop) => {
-        delete info.properties[prop];
-    });
-});
 
 export class GuidedNewDatasetPage extends Page {
     constructor(...args) {
@@ -132,6 +114,9 @@ export class GuidedNewDatasetPage extends Page {
             validateEmptyValues: false,
             dialogOptions: {
                 properties: ["createDirectory"],
+            },
+            onOverride: (name) => {
+                this.notify(`<b>${header(name)}</b> has been overriden with a global value.`, 'warning', 3000)
             },
             validateOnChange,
             onUpdate: () => (this.unsavedUpdates = true),

--- a/src/renderer/src/stories/pages/settings/SettingsPage.js
+++ b/src/renderer/src/stories/pages/settings/SettingsPage.js
@@ -14,20 +14,12 @@ const schema = {
 
 import { Button } from "../../Button.js";
 import { global } from "../../../progress/index.js";
-import { merge } from "../utils.js";
+import { merge, setUndefinedIfNotDeclared } from "../utils.js";
 
 import { notyf } from "../../../dependencies/globals.js";
 import { header } from "../../forms/utils";
 
 const dandiAPITokenRegex = /^[a-f0-9]{40}$/;
-
-const setUndefinedIfNotDeclared = (schema, resolved) => {
-    for (let prop in schema.properties) {
-        const propInfo = schema.properties[prop];
-        if (propInfo) setUndefinedIfNotDeclared(propInfo, resolved[prop]);
-        else if (!(prop in resolved)) resolved[prop] = undefined;
-    }
-};
 
 export class SettingsPage extends Page {
     header = {

--- a/src/renderer/src/stories/pages/utils.js
+++ b/src/renderer/src/stories/pages/utils.js
@@ -18,13 +18,24 @@ const isObject = (o) => {
     return o && typeof o === "object" && !Array.isArray(o);
 };
 
+export const setUndefinedIfNotDeclared = (schemaProps, resolved) => {
+    if ('properties' in schemaProps) schemaProps = schemaProps.properties;
+    for (const prop in schemaProps) {
+        const propInfo = schemaProps[prop]?.properties;
+        if (propInfo) setUndefinedIfNotDeclared(propInfo, resolved[prop]);
+        else if (!(prop in resolved)) resolved[prop] = undefined;
+    }
+};
+
+
 export function merge(toMerge = {}, target = {}, mergeOpts = {}) {
     // Deep merge objects
     for (const [k, v] of Object.entries(toMerge)) {
         const targetV = target[k];
         if (mergeOpts.arrays && Array.isArray(v) && Array.isArray(targetV))
             target[k] = [...targetV, ...v]; // Merge array entries together
-        else if (isObject(v) || isObject(targetV)) target[k] = merge(v, target[k]);
+        else if (isObject(v) || isObject(targetV)) target[k] = merge(v, target[k], mergeOpts);
+        else if (v === undefined) delete target[k]; // Remove matched values
         else target[k] = v; // Replace primitive values
     }
 


### PR DESCRIPTION
This PR allows users to pull up global metadata on demand and edit those properties. The Subject, Source Data, and File Metadata pages all have a new button near the header to toggle Global Metadata editing.

Additional related fixes were included, such as:
- Maintain form state on updates (i.e. accordions will stay open when updated with new globals)
- Do not allow users to specify an empty value if there are globals. Auto-fill with global when cleared—as this is how the property will be interpreted (and rendered on page reload)
- Ensure proper deletion of properties that are set to an empty string / undefined (as previously these would not clear...)

## User Testing Issues
- Made all single-session fixes to experimenter name but did not change the global level
- Missed the idea of the earlier global metadata pages (did not read the description, or was not clear?)
- would be nice to be able to specify the interface kwargs (Source Data Page) at a global / subject-specific level.
- Did not fill out global subject metadata on the Subject Table however, such as species and age [commented on how this was annoying to specify for each session]
- unclear how to triage inspector report feedback (e.g. global metadata is usually the best way to go for recurring issues)