### PR TITLE
Fallback to n_jobs=1 if NWB Inspector fails

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -593,17 +593,21 @@ def inspect_nwb_folder(payload):
     from nwbinspector import inspect_all, load_config
     from nwbinspector.nwbinspector import InspectorOutputJSONEncoder
 
-    messages = list(
-        inspect_all(
-            n_jobs=-2,  # uses number of CPU - 1
-            ignore=[
-                "check_description",
-                "check_data_orientation",
-            ],  # TODO: remove when metadata control is exposed
-            config=load_config(filepath_or_keyword="dandi"),
-            **payload,
-        )
+    kwargs = dict(
+        n_jobs=-2,  # uses number of CPU - 1
+        ignore=[
+            "check_description",
+            "check_data_orientation",
+        ],  # TODO: remove when metadata control is exposed
+        config=load_config(filepath_or_keyword="dandi"),
+        **payload,
     )
+
+    try:
+        messages = list(inspect_all(**kwargs))
+    except:
+        del kwargs['n_jobs']
+        messages = list(inspect_all(**kwargs))
 
     return json.loads(json.dumps(obj=messages, cls=InspectorOutputJSONEncoder))
 

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -607,8 +607,11 @@ def inspect_nwb_folder(payload):
     try:
         messages = list(inspect_all(**kwargs))
     except PicklingError as e:
-        del kwargs["n_jobs"]
-        messages = list(inspect_all(**kwargs))
+        if "attribute lookup auto_parse_some_output on nwbinspector.register_checks failed" in str(e):
+            del kwargs["n_jobs"]
+            messages = list(inspect_all(**kwargs))
+        else:
+            raise e
     except Exception as e:
         raise e
 

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -607,7 +607,7 @@ def inspect_nwb_folder(payload):
     try:
         messages = list(inspect_all(**kwargs))
     except PicklingError as e:
-        del kwargs['n_jobs']
+        del kwargs["n_jobs"]
         messages = list(inspect_all(**kwargs))
     except Exception as e:
         raise e

--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -592,6 +592,7 @@ def inspect_nwb_file(payload):
 def inspect_nwb_folder(payload):
     from nwbinspector import inspect_all, load_config
     from nwbinspector.nwbinspector import InspectorOutputJSONEncoder
+    from pickle import PicklingError
 
     kwargs = dict(
         n_jobs=-2,  # uses number of CPU - 1
@@ -605,9 +606,11 @@ def inspect_nwb_folder(payload):
 
     try:
         messages = list(inspect_all(**kwargs))
-    except:
+    except PicklingError as e:
         del kwargs['n_jobs']
         messages = list(inspect_all(**kwargs))
+    except Exception as e:
+        raise e
 
     return json.loads(json.dumps(obj=messages, cls=InspectorOutputJSONEncoder))
 


### PR DESCRIPTION
This PR is a quick fix for https://github.com/NeurodataWithoutBorders/nwbinspector/issues/415 where the GUIDE will fall back to `n_jobs=1` if using multiple jobs fails.