### PR TITLE
Add missing step in dev install instructions

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -15,6 +15,7 @@ Start by cloning the repository
 .. code-block:: bash
 
     git clone https://github.com/NeurodataWithoutBorders/nwb-guide
+    cd nwb-guide
 
 
 Install Python Dependencies


### PR DESCRIPTION
Minor fix to add `cd nwb-guide` to the dev installation instructions