### PR TITLE
Replace crypto.createCipher with crypto.createCipheriv

### DIFF
--- a/src/renderer/src/dependencies/simple.js
+++ b/src/renderer/src/dependencies/simple.js
@@ -1,4 +1,4 @@
-import { app, isElectron } from "../electron/index.js";
+import { app, crypto, isElectron } from "../electron/index.js";
 import paths from "../../../../paths.config.json" assert { type: "json" };
 import { joinPath } from "../globals.js";
 
@@ -12,11 +12,6 @@ export const homeDirectory = app?.getPath("home") ?? "";
 export const appDirectory = homeDirectory ? joinPath(homeDirectory, paths.root) : "";
 export const guidedProgressFilePath = homeDirectory ? joinPath(appDirectory, ...paths.subfolders.progress) : "";
 
-const KEY_LENGTH = 32;
-export const ENCRYPTION_KEY = homeDirectory
-    ? Buffer.concat([Buffer.from(homeDirectory), Buffer.alloc(KEY_LENGTH)], KEY_LENGTH)
-    : null;
-
 export const previewSaveFolderPath = homeDirectory
     ? joinPath(homeDirectory, paths["root"], ...paths.subfolders.preview)
     : "";
@@ -24,4 +19,16 @@ export const conversionSaveFolderPath = homeDirectory
     ? joinPath(homeDirectory, paths["root"], ...paths.subfolders.conversions)
     : "";
 
+
+
+// Encryption
+const IV_LENGTH = 16;
+const KEY_LENGTH = 32;
+export const ENCRYPTION_KEY = homeDirectory
+    ? Buffer.concat([Buffer.from(homeDirectory), Buffer.alloc(KEY_LENGTH)], KEY_LENGTH)
+    : null;
+
+export const ENCRYPTION_IV = crypto ? crypto.randomBytes(IV_LENGTH) : null;
+
+// Storybook
 export const isStorybook = window.location.href.includes("iframe.html");

--- a/src/renderer/src/dependencies/simple.js
+++ b/src/renderer/src/dependencies/simple.js
@@ -13,8 +13,9 @@ export const appDirectory = homeDirectory ? joinPath(homeDirectory, paths.root) 
 export const guidedProgressFilePath = homeDirectory ? joinPath(appDirectory, ...paths.subfolders.progress) : "";
 
 const KEY_LENGTH = 32;
-export const ENCRYPTION_KEY = homeDirectory ? Buffer.concat([Buffer.from(homeDirectory), Buffer.alloc(KEY_LENGTH)], KEY_LENGTH) : null;
-
+export const ENCRYPTION_KEY = homeDirectory
+    ? Buffer.concat([Buffer.from(homeDirectory), Buffer.alloc(KEY_LENGTH)], KEY_LENGTH)
+    : null;
 
 export const previewSaveFolderPath = homeDirectory
     ? joinPath(homeDirectory, paths["root"], ...paths.subfolders.preview)

--- a/src/renderer/src/dependencies/simple.js
+++ b/src/renderer/src/dependencies/simple.js
@@ -19,8 +19,6 @@ export const conversionSaveFolderPath = homeDirectory
     ? joinPath(homeDirectory, paths["root"], ...paths.subfolders.conversions)
     : "";
 
-
-
 // Encryption
 const IV_LENGTH = 16;
 const KEY_LENGTH = 32;

--- a/src/renderer/src/dependencies/simple.js
+++ b/src/renderer/src/dependencies/simple.js
@@ -12,6 +12,10 @@ export const homeDirectory = app?.getPath("home") ?? "";
 export const appDirectory = homeDirectory ? joinPath(homeDirectory, paths.root) : "";
 export const guidedProgressFilePath = homeDirectory ? joinPath(appDirectory, ...paths.subfolders.progress) : "";
 
+const KEY_LENGTH = 32;
+export const ENCRYPTION_KEY = homeDirectory ? Buffer.concat([Buffer.from(homeDirectory), Buffer.alloc(KEY_LENGTH)], KEY_LENGTH) : null;
+
+
 export const previewSaveFolderPath = homeDirectory
     ? joinPath(homeDirectory, paths["root"], ...paths.subfolders.preview)
     : "";

--- a/src/renderer/src/electron/index.js
+++ b/src/renderer/src/electron/index.js
@@ -14,6 +14,11 @@ export let path = null;
 export let log = null;
 export let crypto = null;
 
+// Used in tests
+try {
+    crypto = require("crypto");
+} catch {}
+
 if (isElectron) {
     try {
         fs = require("fs-extra"); // File System

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -34,8 +34,6 @@ function encode(text) {
    return CRYPTO_VERSION + Buffer.concat([encrypted, cipher.final()]).toString('hex');
 }
 
-console.log('test', encode('test'), decode(encode('test')))
-
 // Try to decode the value
 function decode(text) {
 

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -6,6 +6,7 @@ import {
     isStorybook,
     appDirectory,
     ENCRYPTION_KEY,
+    ENCRYPTION_IV
 } from "../dependencies/simple.js";
 import { fs, crypto } from "../electron/index.js";
 
@@ -20,13 +21,10 @@ export * from "./update";
 
 const CRYPTO_VERSION = "0.0.1"; // NOTE: Update to wipe values created using an outdated encryption algorithm
 const CRYPTO_ALGORITHM = "aes-256-cbc";
-const IV_LENGTH = 16;
-
-const iv = crypto.randomBytes(IV_LENGTH);
 
 function encode(text) {
     if (!crypto) return text;
-    const cipher = crypto.createCipheriv(CRYPTO_ALGORITHM, ENCRYPTION_KEY, iv);
+    const cipher = crypto.createCipheriv(CRYPTO_ALGORITHM, ENCRYPTION_KEY, ENCRYPTION_IV);
 
     const encrypted = cipher.update(text);
     return CRYPTO_VERSION + Buffer.concat([encrypted, cipher.final()]).toString("hex");
@@ -42,7 +40,7 @@ function decode(text) {
     try {
         let textParts = text.split(":");
         let encryptedText = Buffer.from(textParts.join(":"), "hex");
-        let decipher = crypto.createDecipheriv(CRYPTO_ALGORITHM, ENCRYPTION_KEY, iv);
+        let decipher = crypto.createDecipheriv(CRYPTO_ALGORITHM, ENCRYPTION_KEY, ENCRYPTION_IV);
         let decrypted = decipher.update(encryptedText);
         decrypted = Buffer.concat([decrypted, decipher.final()]);
         return decrypted.toString();

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -6,7 +6,7 @@ import {
     isStorybook,
     appDirectory,
     ENCRYPTION_KEY,
-    ENCRYPTION_IV
+    ENCRYPTION_IV,
 } from "../dependencies/simple.js";
 import { fs, crypto } from "../electron/index.js";
 

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -5,7 +5,7 @@ import {
     reloadPageToHome,
     isStorybook,
     appDirectory,
-    homeDirectory,
+    ENCRYPTION_KEY,
 } from "../dependencies/simple.js";
 import { fs, crypto } from "../electron/index.js";
 
@@ -21,8 +21,6 @@ export * from "./update";
 const CRYPTO_VERSION = "0.0.1"; // NOTE: Update to wipe values created using an outdated encryption algorithm
 const CRYPTO_ALGORITHM = "aes-256-cbc";
 const IV_LENGTH = 16;
-const KEY_LENGTH = 32;
-const ENCRYPTION_KEY = Buffer.concat([Buffer.from(homeDirectory), Buffer.alloc(KEY_LENGTH)], KEY_LENGTH);
 
 const iv = crypto.randomBytes(IV_LENGTH);
 

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -18,32 +18,52 @@ import * as operations from "./operations";
 
 export * from "./update";
 
-var re = /[0-9A-Fa-f]{6}/g;
+const CRYPTO_VERSION = "0.0.1"; // NOTE: Update to wipe values created using an outdated encryption algorithm
+const CRYPTO_ALGORITHM = 'aes-256-cbc';
+const IV_LENGTH = 16;
+const KEY_LENGTH = 32;
+const ENCRYPTION_KEY = Buffer.concat([Buffer.from(homeDirectory), Buffer.alloc(KEY_LENGTH)], KEY_LENGTH)
 
-function encode(message) {
-    if (!crypto) return message;
-    const mykey = crypto.createCipher("aes-128-cbc", homeDirectory);
-    const mystr = mykey.update(message, "utf8", "hex");
-    return mystr + mykey.final("hex");
+const iv = crypto.randomBytes(IV_LENGTH);
+
+function encode(text) {
+    if (!crypto) return text;
+    const cipher = crypto.createCipheriv(CRYPTO_ALGORITHM, ENCRYPTION_KEY, iv);
+   
+   const encrypted = cipher.update(text);
+   return CRYPTO_VERSION + Buffer.concat([encrypted, cipher.final()]).toString('hex');
 }
 
+console.log('test', encode('test'), decode(encode('test')))
+
 // Try to decode the value
-function decode(message) {
-    if (!crypto || !/[0-9A-Fa-f]{6}/g.test(message)) return message;
+function decode(text) {
+
+    if (!crypto || !/[0-9A-Fa-f]{6}/g.test(text)) return text;
+    if (text.slice(0, CRYPTO_VERSION.length) !== CRYPTO_VERSION) return undefined;
+
+    text = text.slice(CRYPTO_VERSION.length)
 
     try {
-        const mykey = crypto.createDecipher("aes-128-cbc", homeDirectory);
-        const mystr = mykey.update(message, "hex", "utf8");
-        return mystr + mykey.final("utf8");
+        let textParts = text.split(':');
+        let encryptedText = Buffer.from(textParts.join(':'), 'hex');
+        let decipher = crypto.createDecipheriv(CRYPTO_ALGORITHM, ENCRYPTION_KEY, iv);
+        let decrypted = decipher.update(encryptedText);
+        decrypted = Buffer.concat([decrypted, decipher.final()]);
+        return decrypted.toString();
     } catch {
-        return message;
+        return text;
     }
 }
 
 function drill(o, callback) {
     if (o && typeof o === "object") {
         const copy = Array.isArray(o) ? [...o] : { ...o };
-        for (let k in copy) copy[k] = drill(copy[k], callback);
+        for (let k in copy) {
+            const res = drill(copy[k], callback)
+            if (res) copy[k] = res;
+            else delete copy[k]
+        };
         return copy;
     } else return callback(o);
 }

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedNewDatasetInfo.js
@@ -79,7 +79,10 @@ export class GuidedNewDatasetPage extends Page {
         const schema = { ...projectMetadataSchema };
         schema.properties = { ...schema.properties };
 
-        this.state = merge(global.data, structuredClone(this.info.globalState.project));
+        const globalState = this.info.globalState;
+        if (!globalState.project) globalState.project = {};
+
+        this.state = merge(global.data, structuredClone(globalState.project));
 
         this.form = new JSONSchemaForm({
             schema,


### PR DESCRIPTION
Fixing this error found here: https://github.com/NeurodataWithoutBorders/nwb-guide/pull/522#issuecomment-1834255627

```
(node:3064) [DEP0106] DeprecationWarning: crypto.createDecipher is deprecated.
(Use `electron --trace-deprecation ...` to show where the warning was created)
[5744:1130/123830.054:ERROR:cert_issuer_source_aia.cc(36)] Error parsing cert retrieved from AIA (as DER):
ERROR: Couldn't read tbsCertificate as SEQUENCE
ERROR: Failed parsing Certificate

[5744:1130/123830.641:ERROR:cert_issuer_source_aia.cc(36)] Error parsing cert retrieved from AIA (as DER):
ERROR: Couldn't read tbsCertificate as SEQUENCE
ERROR: Failed parsing Certificate
```

Note that your global variables (e.g. API keys, output locations, etc.) will be wiped since we are not using the same algorithm to decipher those values from the encoded global JSON configuration.