### PR TITLE
Fix Server Error Parsing

### DIFF
--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -104,17 +104,10 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (isStorybook) return;
 
                     if (result.message) {
-
-                        const [
-                            type,
-                            ...splitText
-                        ] = result.message.split(":");
-                        const text = splitText.length ? splitText.join(":") : `<small><pre>${result.traceback
-                            .trim()
-                            .split("\n")
-                            .slice(-2)[0]
-                            .trim()
-                        }</pre></small>`
+                        const [type, ...splitText] = result.message.split(":");
+                        const text = splitText.length
+                            ? splitText.join(":")
+                            : `<small><pre>${result.traceback.trim().split("\n").slice(-2)[0].trim()}</pre></small>`;
 
                         const message = `<h4 style="margin: 0;">Request Failed</h4><small>${type}</small><p>${text}</p>`;
                         this.notify(message, "error");

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -104,14 +104,18 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (isStorybook) return;
 
                     if (result.message) {
+
                         const [
                             type,
-                            text = `<small><pre>${result.traceback
-                                .trim()
-                                .split("\n")
-                                .slice(-2)[0]
-                                .trim()}</pre></small>`,
+                            ...splitText
                         ] = result.message.split(":");
+                        const text = splitText.length ? splitText.join(":") : `<small><pre>${result.traceback
+                            .trim()
+                            .split("\n")
+                            .slice(-2)[0]
+                            .trim()
+                        }</pre></small>`
+
                         const message = `<h4 style="margin: 0;">Request Failed</h4><small>${type}</small><p>${text}</p>`;
                         this.notify(message, "error");
                         throw result;

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -106,7 +106,7 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (result.message) {
                         const [type, ...splitText] = result.message.split(":");
                         const text = splitText.length
-                            ? splitText.join(":")
+                            ? splitText.join(":").replaceAll('<', '&lt').replaceAll('>', '&gt')
                             : `<small><pre>${result.traceback.trim().split("\n").slice(-2)[0].trim()}</pre></small>`;
 
                         const message = `<h4 style="margin: 0;">Request Failed</h4><small>${type}</small><p>${text}</p>`;

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedSourceData.js
@@ -106,7 +106,7 @@ export class GuidedSourceDataPage extends ManagedPage {
                     if (result.message) {
                         const [type, ...splitText] = result.message.split(":");
                         const text = splitText.length
-                            ? splitText.join(":").replaceAll('<', '&lt').replaceAll('>', '&gt')
+                            ? splitText.join(":").replaceAll("<", "&lt").replaceAll(">", "&gt")
                             : `<small><pre>${result.traceback.trim().split("\n").slice(-2)[0].trim()}</pre></small>`;
 
                         const message = `<h4 style="margin: 0;">Request Failed</h4><small>${type}</small><p>${text}</p>`;


### PR DESCRIPTION
fix #544 

Was excluding any strings after the second (or later) colon when parsing error messages from the server.