### PR TITLE
First Round of Updates from Oliver User Test

### DIFF
--- a/schemas/base-metadata.schema.ts
+++ b/schemas/base-metadata.schema.ts
@@ -59,6 +59,9 @@ export const preprocessMetadataSchema = (schema: any = baseMetadataSchema, globa
         description: 'The species of your subject.'
     }
 
+    // copy.order = ['NWBFile', 'Subject']
+
+    copy.properties.NWBFile.title = 'General Metadata'
     const nwbProps = copy.properties.NWBFile.properties
     nwbProps.related_publications.description = "Provide a PMID, DOI, URL, etc. for each publication."
     nwbProps.related_publications.items.description = "Provide a PMID, DOI, URL, etc."

--- a/schemas/base-metadata.schema.ts
+++ b/schemas/base-metadata.schema.ts
@@ -63,8 +63,8 @@ export const preprocessMetadataSchema = (schema: any = baseMetadataSchema, globa
 
     copy.properties.NWBFile.title = 'General Metadata'
     const nwbProps = copy.properties.NWBFile.properties
-    nwbProps.related_publications.description = "Provide a PMID, DOI, URL, etc. for each publication."
-    nwbProps.related_publications.items.description = "Provide a PMID, DOI, URL, etc."
+    nwbProps.related_publications.description = "Provide a DOI for each publication."
+    nwbProps.related_publications.items.description = "Provide a DOI"
 
     nwbProps.keywords.items.description = "Provide a single keyword (e.g. Neural circuits, V1, etc.)"
 

--- a/schemas/base-metadata.schema.ts
+++ b/schemas/base-metadata.schema.ts
@@ -59,6 +59,10 @@ export const preprocessMetadataSchema = (schema: any = baseMetadataSchema, globa
         description: 'The species of your subject.'
     }
 
+    const nwbProps = copy.properties.NWBFile.properties
+    nwbProps.related_publications.description = "Provide a PMID, DOI, URL, etc. for each publication."
+    nwbProps.related_publications.items.description = "Provide a PMID, DOI, URL, etc."
+
     // Resolve species suggestions
     resolve(serverGlobals.species, (res) => {
         const info = getSpeciesInfo(res)

--- a/schemas/base-metadata.schema.ts
+++ b/schemas/base-metadata.schema.ts
@@ -63,6 +63,8 @@ export const preprocessMetadataSchema = (schema: any = baseMetadataSchema, globa
     nwbProps.related_publications.description = "Provide a PMID, DOI, URL, etc. for each publication."
     nwbProps.related_publications.items.description = "Provide a PMID, DOI, URL, etc."
 
+    nwbProps.keywords.items.description = "Provide a single keyword (e.g. Neural circuits, V1, etc.)"
+
     // Resolve species suggestions
     resolve(serverGlobals.species, (res) => {
         const info = getSpeciesInfo(res)

--- a/schemas/base-metadata.schema.ts
+++ b/schemas/base-metadata.schema.ts
@@ -63,9 +63,6 @@ export const preprocessMetadataSchema = (schema: any = baseMetadataSchema, globa
 
     copy.properties.NWBFile.title = 'General Metadata'
     const nwbProps = copy.properties.NWBFile.properties
-    nwbProps.related_publications.description = "Provide a DOI for each publication."
-    nwbProps.related_publications.items.description = "Provide a DOI"
-
     nwbProps.keywords.items.description = "Provide a single keyword (e.g. Neural circuits, V1, etc.)"
 
     // Resolve species suggestions
@@ -75,10 +72,14 @@ export const preprocessMetadataSchema = (schema: any = baseMetadataSchema, globa
     })
 
     // Ensure experimenter schema has custom structure
-    copy.properties.NWBFile.properties.experimenter = baseMetadataSchema.properties.NWBFile.properties.experimenter
+    nwbProps.experimenter = baseMetadataSchema.properties.NWBFile.properties.experimenter
+
+    // Ensure related_publications schema has custom structure
+    nwbProps.related_publications = baseMetadataSchema.properties.NWBFile.properties.related_publications
+
 
     // Override description of keywords
-    copy.properties.NWBFile.properties.keywords.description = 'Terms to describe your dataset (e.g. Neural circuits, V1, etc.)' // Add description to keywords
+    nwbProps.keywords.description = 'Terms to describe your dataset (e.g. Neural circuits, V1, etc.)' // Add description to keywords
 
 
 

--- a/schemas/json/base_metadata_schema.json
+++ b/schemas/json/base_metadata_schema.json
@@ -90,11 +90,11 @@
           "description": "Provide a DOI for each publication.",
           "items": {
             "type": "string",
-            "format": "doi:{doi}",
+            "format": "{doi}",
             "properties": {
               "doi": {
                 "title": "DOI",
-                "pattern": "^\\b(10[.][0-9]{4,}(?:[.][0-9]+)*\\/(?:(?![\"&\\'<>])\\S)+)\\b$",
+                "pattern": "^(doi:|http:\/\/dx\\.doi\\.org/|https:\/\/doi\\.org\/)\\b(10[.][0-9]{4,}(?:[.][0-9]+)*\\/(?:(?![\"&\\'<>])\\S)+)\\b$",
                 "type": "string",
                 "description": "Provide your publication formatted as a digital object identifier (DOI), e.g., doi:10.1038/nn.1234."
               }

--- a/schemas/json/base_metadata_schema.json
+++ b/schemas/json/base_metadata_schema.json
@@ -87,9 +87,19 @@
         },
         "related_publications": {
           "type": "array",
+          "description": "Provide a DOI for each publication.",
           "items": {
-            "title": "related publication",
-            "type": "string"
+            "type": "string",
+            "format": "doi:{doi}",
+            "properties": {
+              "doi": {
+                "title": "DOI",
+                "pattern": "^\\b(10[.][0-9]{4,}(?:[.][0-9]+)*\\/(?:(?![\"&\\'<>])\\S)+)\\b$",
+                "type": "string",
+                "description": "Provide your publication formatted as a digital object identifier (DOI), e.g., doi:10.1038/nn.1234."
+              }
+            },
+            "required": [ "doi" ]
           }
         },
         "slices": {

--- a/schemas/json/base_metadata_schema.json
+++ b/schemas/json/base_metadata_schema.json
@@ -96,7 +96,7 @@
                 "title": "DOI",
                 "pattern": "^(doi:|http:\/\/dx\\.doi\\.org/|https:\/\/doi\\.org\/)\\b(10[.][0-9]{4,}(?:[.][0-9]+)*\\/(?:(?![\"&\\'<>])\\S)+)\\b$",
                 "type": "string",
-                "description": "Provide your publication formatted as a digital object identifier (DOI), e.g., doi:10.1038/nn.1234."
+                "description": "Provide your publication formatted as a digital object identifier (DOI), e.g., doi:10.1038/nn.1234 or https://doi.org/10.1038/nn.1234."
               }
             },
             "required": [ "doi" ]

--- a/src/renderer/src/pages.js
+++ b/src/renderer/src/pages.js
@@ -116,7 +116,7 @@ const pages = {
             }),
 
             structure: new GuidedStructurePage({
-                title: "Data Formats",
+                title: "Provide Data Formats",
                 label: "Data formats",
                 section: sections[0],
             }),
@@ -134,7 +134,7 @@ const pages = {
             }),
 
             sourcedata: new GuidedSourceDataPage({
-                title: "Source Data",
+                title: "Source Data Information",
                 label: "Source data",
                 section: sections[1],
             }),

--- a/src/renderer/src/stories/Accordion.js
+++ b/src/renderer/src/stories/Accordion.js
@@ -238,11 +238,7 @@ export class Accordion extends LitElement {
         else if (this.disabled) return false; // Force closed if disabled
         return state;
     };
-
-    updated() {
-        console.log(this)
-    }
-
+    
     render() {
         const isToggleable = this.content && this.toggleable;
 

--- a/src/renderer/src/stories/Accordion.js
+++ b/src/renderer/src/stories/Accordion.js
@@ -238,7 +238,7 @@ export class Accordion extends LitElement {
         else if (this.disabled) return false; // Force closed if disabled
         return state;
     };
-    
+
     render() {
         const isToggleable = this.content && this.toggleable;
 

--- a/src/renderer/src/stories/Accordion.js
+++ b/src/renderer/src/stories/Accordion.js
@@ -239,6 +239,10 @@ export class Accordion extends LitElement {
         return state;
     };
 
+    updated() {
+        console.log(this)
+    }
+
     render() {
         const isToggleable = this.content && this.toggleable;
 

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -205,7 +205,7 @@ export class JSONSchemaForm extends LitElement {
 
     base = [];
     #nestedForms = {};
-    inputs = []
+    inputs = [];
 
     tables = {};
     #nErrors = 0;
@@ -535,7 +535,7 @@ export class JSONSchemaForm extends LitElement {
             validateEmptyValue: this.validateEmptyValues,
         });
 
-        this.inputs.push(interactiveInput)
+        this.inputs.push(interactiveInput);
 
         // this.validateEmptyValues ? undefined : (el) => (el.value ?? el.checked) !== ""
 
@@ -556,7 +556,14 @@ export class JSONSchemaForm extends LitElement {
                     : ""}"
             >
                 <label class="guided--form-label">${info.title ?? header(name)} </label>
-                ${this.showPath ? html`  <small>${externalPath.slice(0, -1).map(str => header(str ?? '')).join('.')}</small>` : ''}
+                ${this.showPath
+                    ? html` <small
+                          >${externalPath
+                              .slice(0, -1)
+                              .map((str) => header(str ?? ""))
+                              .join(".")}</small
+                      >`
+                    : ""}
                 ${interactiveInput}
                 <div class="errors"></div>
                 <div class="warnings"></div>
@@ -669,16 +676,16 @@ export class JSONSchemaForm extends LitElement {
 
     #getLink = (args) => {
         if (typeof args === "string") args = args.split("-");
-        const group  = this.#getGroup(args);
+        const group = this.#getGroup(args);
         if (!group) return;
         return group.validate ? group : undefined;
-    }
+    };
 
     #getGroup = (args) => {
         if (typeof args === "string") args = args.split("-");
         const group = this.groups.find((linked) => linked.properties.find((link) => link.join("-") === args.join("-")));
-        return group
-    }
+        return group;
+    };
 
     #applyToLinkedProperties = (fn, externalPath) => {
         const links = this.#getLink(externalPath)?.properties;
@@ -890,8 +897,6 @@ export class JSONSchemaForm extends LitElement {
     #accordions = {};
 
     #render = (schema, results, required = {}, path = []) => {
-
-        
         let isLink = Symbol("isLink");
         // Filter non-required properties (if specified) and render the sub-schema
         const renderable = this.#getRenderable(schema, required, path);
@@ -951,7 +956,7 @@ export class JSONSchemaForm extends LitElement {
 
                 if (e1[isLink] || e2[isLink]) return 0;
 
-                if (info2.properties && info.properties)  return 0
+                if (info2.properties && info.properties) return 0;
                 else if (info2.properties) return -1;
                 else if (info.properties) return 1;
                 else return 0;
@@ -1190,7 +1195,7 @@ export class JSONSchemaForm extends LitElement {
     #resetLoadState() {
         this.#loaded = false;
         this.nLoaded = 0;
-        this.inputs = []
+        this.inputs = [];
     }
 
     // Check if everything is internally rendered

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -51,9 +51,13 @@ const componentCSS = `
     .guided--form-label {
       display: block;
       width: 100%;
-      margin: 1.45rem 0 0.45rem 0;
+      margin-top: 1.45rem;
       color: black;
       font-weight: 600;
+    }
+
+    jsonschema-input {
+        margin-top: 0.45rem;
     }
 
     .form-section:first-child .guided--form-label {
@@ -123,7 +127,7 @@ const componentCSS = `
     }
 
   .required label:after {
-    content: " *";
+    content: "*";
     color: #ff0033;
 
   }
@@ -161,6 +165,10 @@ const componentCSS = `
     [disabled]{
         opacity: 0.5;
         pointer-events: none;
+    }
+
+    small {
+        font-size: 0.8em;
     }
 `;
 
@@ -220,6 +228,8 @@ export class JSONSchemaForm extends LitElement {
         this.dialogOptions = props.dialogOptions;
         this.dialogType = props.dialogType;
         this.deferLoading = props.deferLoading ?? false;
+
+        this.showPath = props.showPath ?? false;
 
         this.controls = props.controls ?? {};
 
@@ -536,7 +546,8 @@ export class JSONSchemaForm extends LitElement {
                     ? "conditional"
                     : ""}"
             >
-                <label class="guided--form-label">${info.title ?? header(name)}</label>
+                <label class="guided--form-label">${info.title ?? header(name)} </label>
+                ${this.showPath ? html`  <small>${externalPath.slice(0, -1).map(str => header(str ?? '')).join('.')}</small>` : ''}
                 ${interactiveInput}
                 <div class="errors"></div>
                 <div class="warnings"></div>
@@ -893,11 +904,13 @@ export class JSONSchemaForm extends LitElement {
 
             // Sort alphabetically
             .sort(([name], [name2]) => {
-                if (name.toLowerCase() < name2.toLowerCase()) {
-                    return -1;
-                }
-                if (name.toLowerCase() > name2.toLowerCase()) {
+                const header1 = header(name);
+                const header2 = header(name2);
+                if (header1.toLowerCase() < header2.toLowerCase()) {
                     return 1;
+                }
+                if (header1.toLowerCase() > header2.toLowerCase()) {
+                    return -1;
                 }
                 return 0;
             })
@@ -939,6 +952,7 @@ export class JSONSchemaForm extends LitElement {
         }
 
         const finalSort = this.sort ? sorted.sort(this.sort) : sorted;
+        console.log(sorted)
 
         let rendered = finalSort.map((entry) => {
             const [name, info] = entry;
@@ -982,7 +996,7 @@ export class JSONSchemaForm extends LitElement {
                 style: "margin-right: 10px; pointer-events:all;",
             });
 
-            const headerName = header(name);
+            const headerName = header(info.title ?? name);
 
             const renderableInside = this.#getRenderable(info, required[name], localPath, true);
 
@@ -1021,6 +1035,7 @@ export class JSONSchemaForm extends LitElement {
 
                     required: required[name], // Scoped to the sub-schema
                     ignore: this.ignore,
+                    showPath: this.showPath,
                     dialogOptions: this.dialogOptions,
                     dialogType: this.dialogType,
                     onlyRequired: this.onlyRequired,

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -51,17 +51,17 @@ const componentCSS = `
     .guided--form-label {
       display: block;
       width: 100%;
-      margin-top: 1.45rem;
+      margin: 1.45rem 0 0 0;
       color: black;
       font-weight: 600;
     }
 
-    jsonschema-input {
-        margin-top: 0.45rem;
-    }
-
     .form-section:first-child .guided--form-label {
       margin-top: 0;
+    }
+
+    jsonschema-input {
+        margin-top: 0.5rem;
     }
 
     .guided--form-label {
@@ -907,10 +907,10 @@ export class JSONSchemaForm extends LitElement {
                 const header1 = header(name);
                 const header2 = header(name2);
                 if (header1.toLowerCase() < header2.toLowerCase()) {
-                    return 1;
+                    return -1;
                 }
                 if (header1.toLowerCase() > header2.toLowerCase()) {
-                    return -1;
+                    return 1;
                 }
                 return 0;
             })
@@ -936,7 +936,8 @@ export class JSONSchemaForm extends LitElement {
 
                 if (e1[isLink] || e2[isLink]) return 0;
 
-                if (info2.properties) return -1;
+                if (info2.properties && info.properties)  return 0
+                else if (info2.properties) return -1;
                 else if (info.properties) return 1;
                 else return 0;
             });

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -188,6 +188,8 @@ export class JSONSchemaForm extends LitElement {
 
     base = [];
     #nestedForms = {};
+    inputs = []
+
     tables = {};
     #nErrors = 0;
     #nWarnings = 0;
@@ -513,6 +515,8 @@ export class JSONSchemaForm extends LitElement {
             required: isRequired,
             validateEmptyValue: this.validateEmptyValues,
         });
+
+        this.inputs.push(interactiveInput)
 
         // this.validateEmptyValues ? undefined : (el) => (el.value ?? el.checked) !== ""
 
@@ -859,6 +863,8 @@ export class JSONSchemaForm extends LitElement {
     #accordions = {};
 
     #render = (schema, results, required = {}, path = []) => {
+
+        
         let isLink = Symbol("isLink");
         // Filter non-required properties (if specified) and render the sub-schema
         const renderable = this.#getRenderable(schema, required, path);
@@ -1154,6 +1160,7 @@ export class JSONSchemaForm extends LitElement {
     #resetLoadState() {
         this.#loaded = false;
         this.nLoaded = 0;
+        this.inputs = []
     }
 
     // Check if everything is internally rendered

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -13,6 +13,7 @@ import { JSONSchemaInput } from "./JSONSchemaInput";
 import { InspectorListItem } from "./preview/inspector/InspectorList";
 
 import { Validator } from "jsonschema";
+import { successHue, warningHue, errorHue } from "./globals";
 
 var v = new Validator();
 
@@ -98,18 +99,26 @@ const componentCSS = `
       font-weight: bold;
     }
 
-    .link.required::after {
-      box-sizing: border-box;
-      display: block;
-      width: 10px;
-      height: 10px;
-      background: #ff3d64;
-      border-radius: 50%;
-      position: absolute;
-      top: 0;
-      right: 0;
-      content: '';
-      margin: 15px;
+    .link::after {
+        box-sizing: border-box;
+        display: block;
+        width: 10px;
+        height: 10px;
+        background: hsl(${successHue}, 100%, 70%) !important;
+        border-radius: 50%;
+        position: absolute;
+        top: 0;
+        right: 0;
+        content: '';
+        margin: 15px;
+      }
+
+    .link.error::after {
+        background: hsl(${errorHue}, 100%, 70%) !important;
+    }
+
+    .link.warning::after {
+        background: hsl(${warningHue}, 100%, 70%) !important;
     }
 
     hr {
@@ -846,10 +855,13 @@ export class JSONSchemaForm extends LitElement {
 
         const groupEl = this.#getGroupElement(externalPath);
 
+        if (groupEl) {
+            groupEl.classList[resolvedErrors.length ? "add" : "remove"]("error");
+            groupEl.classList[warnings.length ? "add" : "remove"]("warning");
+        }
+
         if (isValid && resolvedErrors.length === 0) {
             input.classList.remove("invalid");
-
-            if (groupEl) groupEl.classList.remove("required", "conditional");
 
             await this.#applyToLinkedProperties((path, element) => {
                 element.classList.remove("required", "conditional"); // Links manage their own error and validity states, but only one needs to be valid
@@ -861,8 +873,6 @@ export class JSONSchemaForm extends LitElement {
         } else {
             // Add new invalid classes and errors
             input.classList.add("invalid");
-
-            if (groupEl) groupEl.classList.add("required", "conditional");
 
             // Only add the conditional class for linked elements
             await this.#applyToLinkedProperties(

--- a/src/renderer/src/stories/JSONSchemaForm.stories.js
+++ b/src/renderer/src/stories/JSONSchemaForm.stories.js
@@ -105,7 +105,7 @@ Linked.args = {
         },
         required: ["required"],
     },
-    conditionalRequirements: [
+    groups: [
         {
             name: "Subject Age",
             properties: [["age"], ["date_of_birth"]],

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -21,28 +21,24 @@ const isFilesystemSelector = (name, format) => {
     return ["file", "directory"].includes(format) ? format : null; // Handle file and directory formats
 };
 
-function getFirstFocusableElement (element) {
-    const root = element.shadowRoot || element
-    const focusableElements = getKeyboardFocusableElements(root)
+function getFirstFocusableElement(element) {
+    const root = element.shadowRoot || element;
+    const focusableElements = getKeyboardFocusableElements(root);
     if (focusableElements.length === 0) {
         for (let child of root.children) {
-            const focusableElement = getFirstFocusableElement(child)
-            if (focusableElement) return focusableElement
+            const focusableElement = getFirstFocusableElement(child);
+            if (focusableElement) return focusableElement;
         }
     }
-    return focusableElements[0]
+    return focusableElements[0];
 }
 
 function getKeyboardFocusableElements(element = document) {
     const root = element.shadowRoot || element;
     return [
-      ...root.querySelectorAll(
-        'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])',
-      ),
-    ].filter(
-      el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'),
-    )
-  }
+        ...root.querySelectorAll('a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])'),
+    ].filter((el) => !el.hasAttribute("disabled") && !el.getAttribute("aria-hidden"));
+}
 
 export class JSONSchemaInput extends LitElement {
     static get styles() {
@@ -228,27 +224,27 @@ export class JSONSchemaInput extends LitElement {
     #handleNextInput = (idx) => {
         const next = this.form.inputs[idx];
         if (next) {
-            const el = getFirstFocusableElement(next)
+            const el = getFirstFocusableElement(next);
             if (el) {
-                if (el.tagName === 'BUTTON') return this.#handleNextInput(idx + 1)
+                if (el.tagName === "BUTTON") return this.#handleNextInput(idx + 1);
                 el.focus();
                 // if (el.tagName === 'INPUT') return
                 // else el.blur()
             }
         }
-    }
+    };
 
     #moveToNextInput = (ev) => {
-            if (ev.key === "Enter") {
-                ev.preventDefault();
-                if (this.form) {
-                    const idx = this.form.inputs.findIndex((input) => input === this);
-                    this.#handleNextInput(idx + 1)
-                }
-                
-                ev.target.blur();
+        if (ev.key === "Enter") {
+            ev.preventDefault();
+            if (this.form) {
+                const idx = this.form.inputs.findIndex((input) => input === this);
+                this.#handleNextInput(idx + 1);
             }
-    }
+
+            ev.target.blur();
+        }
+    };
 
     #render() {
         const { validateOnChange, info, path: fullPath } = this;

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -21,6 +21,29 @@ const isFilesystemSelector = (name, format) => {
     return ["file", "directory"].includes(format) ? format : null; // Handle file and directory formats
 };
 
+function getFirstFocusableElement (element) {
+    const root = element.shadowRoot || element
+    const focusableElements = getKeyboardFocusableElements(root)
+    if (focusableElements.length === 0) {
+        for (let child of root.children) {
+            const focusableElement = getFirstFocusableElement(child)
+            if (focusableElement) return focusableElement
+        }
+    }
+    return focusableElements[0]
+}
+
+function getKeyboardFocusableElements(element = document) {
+    const root = element.shadowRoot || element;
+    return [
+      ...root.querySelectorAll(
+        'a[href], button, input, textarea, select, details,[tabindex]:not([tabindex="-1"])',
+      ),
+    ].filter(
+      el => !el.hasAttribute('disabled') && !el.getAttribute('aria-hidden'),
+    )
+  }
+
 export class JSONSchemaInput extends LitElement {
     static get styles() {
         return css`
@@ -201,6 +224,31 @@ export class JSONSchemaInput extends LitElement {
     }
 
     #onThrow = (...args) => (this.onThrow ? this.onThrow(...args) : this.form?.onThrow(...args));
+
+    #handleNextInput = (idx) => {
+        const next = this.form.inputs[idx];
+        if (next) {
+            const el = getFirstFocusableElement(next)
+            if (el) {
+                if (el.tagName === 'BUTTON') return this.#handleNextInput(idx + 1)
+                el.focus();
+                // if (el.tagName === 'INPUT') return
+                // else el.blur()
+            }
+        }
+    }
+
+    #moveToNextInput = (ev) => {
+            if (ev.key === "Enter") {
+                ev.preventDefault();
+                if (this.form) {
+                    const idx = this.form.inputs.findIndex((input) => input === this);
+                    this.#handleNextInput(idx + 1)
+                }
+                
+                ev.target.blur();
+            }
+    }
 
     #render() {
         const { validateOnChange, info, path: fullPath } = this;
@@ -407,6 +455,8 @@ export class JSONSchemaInput extends LitElement {
                 search.classList.add("schema-input");
                 search.onchange = () => validateOnChange && this.#triggerValidation(name, path); // Ensure validation on forced change
 
+                search.addEventListener("keydown", this.#moveToNextInput);
+
                 return search;
             }
 
@@ -415,6 +465,7 @@ export class JSONSchemaInput extends LitElement {
                     class="guided--input schema-input"
                     @input=${(ev) => this.#updateData(fullPath, info.enum[ev.target.value])}
                     @change=${(ev) => validateOnChange && this.#triggerValidation(name, path)}
+                    @keydown=${this.#moveToNextInput}
                 >
                     <option disabled selected value>${info.placeholder ?? "Select an option"}</option>
                     ${info.enum.map(
@@ -453,6 +504,7 @@ export class JSONSchemaInput extends LitElement {
                         this.#updateData(fullPath, ev.target.value);
                     }}
                     @change=${(ev) => validateOnChange && this.#triggerValidation(name, path)}
+                    @keydown=${this.#moveToNextInput}
                 ></textarea>`;
             // Handle other string formats
             else {
@@ -497,6 +549,7 @@ export class JSONSchemaInput extends LitElement {
                             this.#updateData(fullPath, value);
                         }}
                         @change=${(ev) => validateOnChange && this.#triggerValidation(name, path)}
+                        @keydown=${this.#moveToNextInput}
                     />
                 `;
             }

--- a/src/renderer/src/stories/List.ts
+++ b/src/renderer/src/stories/List.ts
@@ -61,7 +61,7 @@ export class List extends LitElement {
 
 
       ol:not(:has(li)) {
-        margin: 0;
+        margin-top: 0;
       }
 
 

--- a/src/renderer/src/stories/List.ts
+++ b/src/renderer/src/stories/List.ts
@@ -60,6 +60,10 @@ export class List extends LitElement {
       }
 
 
+      ol:not(:has(li)) {
+        margin: 0;
+      }
+
 
       :host([unordered]) ol {
         list-style-type: none;

--- a/src/renderer/src/stories/List.ts
+++ b/src/renderer/src/stories/List.ts
@@ -61,7 +61,7 @@ export class List extends LitElement {
 
 
       ol:not(:has(li)) {
-        margin-top: 0;
+        margin: 0px;
       }
 
 
@@ -345,7 +345,7 @@ export class List extends LitElement {
 
       return html`
       <ol style=${styleMap(this.listStyles)}>
-        ${(items.length || !emptyMessage) ? items.map(this.#renderListItem) : html`<div id="empty">${emptyMessage}</div>`}
+        ${(items.length || !emptyMessage) ? items.map(this.#renderListItem) : html`<li id="empty">${emptyMessage}</li>`}
       </ol>`
     }
   }

--- a/src/renderer/src/stories/Search.js
+++ b/src/renderer/src/stories/Search.js
@@ -33,7 +33,7 @@ export class Search extends LitElement {
             this.setAttribute("interacted", false);
             this.#onSelect(this.getSelectedOption());
         }
-    }
+    };
 
     #value;
 
@@ -403,11 +403,11 @@ export class Search extends LitElement {
           const input = ev.target.value;
           this.#populate(input);
       }}
-      
+
       @blur=${(ev) => {
-            this.submit();
-        }}
-      
+          this.submit();
+      }}
+
       ></input>
       ${unsafeHTML(searchSVG)}
     </div>

--- a/src/renderer/src/stories/Search.js
+++ b/src/renderer/src/stories/Search.js
@@ -25,12 +25,14 @@ export class Search extends LitElement {
         this.headerStyles = headerStyles;
         if (onSelect) this.onSelect = onSelect;
 
-        document.addEventListener("click", () => {
-            if (this.listMode === "click" && this.getAttribute("interacted") === "true") {
-                this.setAttribute("interacted", false);
-                this.#onSelect(this.getSelectedOption());
-            }
-        });
+        document.addEventListener("click", () => this.submit());
+    }
+
+    submit = () => {
+        if (this.listMode === "click" && this.getAttribute("interacted") === "true") {
+            this.setAttribute("interacted", false);
+            this.#onSelect(this.getSelectedOption());
+        }
     }
 
     #value;
@@ -400,7 +402,13 @@ export class Search extends LitElement {
       }} @input=${(ev) => {
           const input = ev.target.value;
           this.#populate(input);
-      }}></input>
+      }}
+      
+      @blur=${(ev) => {
+            this.submit();
+        }}
+      
+      ></input>
       ${unsafeHTML(searchSVG)}
     </div>
     ${this.list}

--- a/src/renderer/src/stories/forms/GlobalFormModal.ts
+++ b/src/renderer/src/stories/forms/GlobalFormModal.ts
@@ -10,9 +10,11 @@ import { save } from "../../progress/index.js";
 type BaseFormModalOptions = {
     header: string
     schema: any
-    propsToIgnore?: string[]
     propsToRemove?: string[]
-    validateOnChange?: Function,
+    formProps: {
+        validateOnChange?: Function,
+        [key: string]: any
+    },
     hasInstances?: boolean
 }
 
@@ -21,9 +23,8 @@ export function createFormModal ({
     onSave,
     header,
     schema,
-    propsToIgnore = [],
     propsToRemove = [],
-    validateOnChange,
+    formProps,
     hasInstances = false
 }: BaseFormModalOptions & { onSave: Function }) {
     const modal = new Modal({
@@ -45,9 +46,8 @@ export function createFormModal ({
         validateEmptyValues: false,
         schema: schemaCopy,
         emptyMessage: "No properties to edit globally.",
-        ignore: propsToIgnore,
         onThrow,
-        validateOnChange
+        ...formProps
     })
 
     content.append(globalForm)
@@ -75,9 +75,8 @@ export function createFormModal ({
 export function createGlobalFormModal(this: Page, {
     header,
     schema,
-    propsToIgnore = [],
     propsToRemove = [],
-    validateOnChange,
+    formProps,
 
     // Global-specific options
     key,
@@ -91,9 +90,8 @@ export function createGlobalFormModal(this: Page, {
     return createFormModal({
         header,
         schema,
-        propsToIgnore,
         propsToRemove,
-        validateOnChange,
+        formProps,
         hasInstances,
         onSave: async ( form ) => {
 

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -94,7 +94,7 @@ export class GuidedMetadataPage extends ManagedPage {
             formProps: {
                 showPath: true,
                 validateOnChange,
-            }
+            },
         }));
         document.body.append(modal);
     }
@@ -171,20 +171,16 @@ export class GuidedMetadataPage extends ManagedPage {
                         ["Subject", "age"],
                         ["Subject", "date_of_birth"],
                     ],
-                    validate: true
+                    validate: true,
                 },
                 {
                     name: "Institutional Info",
                     properties: [
                         ["NWBFile", "institution"],
-                        ["NWBFile", "lab"]
+                        ["NWBFile", "lab"],
                     ],
-                }
+                },
             ],
-
-            
-
-
 
             // deferLoading: true,
             onLoaded: () => {

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -91,7 +91,10 @@ export class GuidedMetadataPage extends ManagedPage {
                 merge(globalResolved, globals);
                 return resolveGlobalOverrides(this.subject, globals);
             },
-            validateOnChange,
+            formProps: {
+                showPath: true,
+                validateOnChange,
+            }
         }));
         document.body.append(modal);
     }

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -155,6 +155,7 @@ export class GuidedMetadataPage extends ManagedPage {
                 this.notify(`<b>${header(name)}</b> has been overriden with a global value.`, "warning", 3000);
             },
 
+            showPath: true,
             transformErrors: (e) => {
                 // JSON Schema Exceptions
                 if (e.message.includes('does not conform to the "date-time" format.')) return false;

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -164,15 +164,27 @@ export class GuidedMetadataPage extends ManagedPage {
                 if (e.message.includes('does not conform to the "date-time" format.')) return false;
             },
 
-            conditionalRequirements: [
+            groups: [
                 {
                     name: "Subject Age",
                     properties: [
                         ["Subject", "age"],
                         ["Subject", "date_of_birth"],
                     ],
+                    validate: true
                 },
+                {
+                    name: "Institutional Info",
+                    properties: [
+                        ["NWBFile", "institution"],
+                        ["NWBFile", "lab"]
+                    ],
+                }
             ],
+
+            
+
+
 
             // deferLoading: true,
             onLoaded: () => {

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -92,7 +92,6 @@ export class GuidedMetadataPage extends ManagedPage {
                 return resolveGlobalOverrides(this.subject, globals);
             },
             formProps: {
-                showPath: true,
                 validateOnChange,
             },
         }));
@@ -158,7 +157,6 @@ export class GuidedMetadataPage extends ManagedPage {
                 this.notify(`<b>${header(name)}</b> has been overriden with a global value.`, "warning", 3000);
             },
 
-            showPath: true,
             transformErrors: (e) => {
                 // JSON Schema Exceptions
                 if (e.message.includes('does not conform to the "date-time" format.')) return false;

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedStructure.js
@@ -9,7 +9,7 @@ import { Modal } from "../../../Modal";
 import { List } from "../../../List";
 import { baseUrl } from "../../../../server/globals";
 
-const defaultEmptyMessage = "No interfaces selected";
+const defaultEmptyMessage = "No formats selected";
 
 const categories = [
     {
@@ -33,7 +33,7 @@ export class GuidedStructurePage extends Page {
             this.searchModal.toggle(false);
         };
 
-        this.addButton.innerText = "Add Interface";
+        this.addButton.innerText = "Add Format";
         this.addButton.onClick = () => {
             this.searchModal.toggle(true);
         };
@@ -42,7 +42,7 @@ export class GuidedStructurePage extends Page {
     }
 
     header = {
-        subtitle: "Select all interfaces which apply to this experiment",
+        subtitle: "List all the data formats in your dataset.",
     };
 
     search = new Search({
@@ -109,7 +109,7 @@ export class GuidedStructurePage extends Page {
     async updated() {
         const { interfaces = {} } = this.info.globalState;
 
-        this.list.emptyMessage = "Loading valid interfaces...";
+        this.list.emptyMessage = "Loading valid formats...";
 
         this.search.options = await fetch(`${baseUrl}/neuroconv`)
             .then((res) => res.json())

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
@@ -77,7 +77,7 @@ export class GuidedUploadPage extends Page {
                     const value = parent[name];
                     if (name.includes("api_key")) return await validateDANDIApiKey(value, name.includes("staging"));
                 },
-            }
+            },
         }));
         document.body.append(modal);
     }

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedUpload.js
@@ -72,10 +72,12 @@ export class GuidedUploadPage extends Page {
                 const input = this.form.getInput(["dandiset "]);
                 input.requestUpdate();
             },
-            validateOnChange: async (name, parent) => {
-                const value = parent[name];
-                if (name.includes("api_key")) return await validateDANDIApiKey(value, name.includes("staging"));
-            },
+            formProps: {
+                validateOnChange: async (name, parent) => {
+                    const value = parent[name];
+                    if (name.includes("api_key")) return await validateDANDIApiKey(value, name.includes("staging"));
+                },
+            }
         }));
         document.body.append(modal);
     }

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedSubjects.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedSubjects.js
@@ -85,9 +85,11 @@ export class GuidedSubjectsPage extends Page {
             header: "Global Subject Metadata",
             key: "Subject",
             schema: preprocessMetadataSchema(undefined, true).properties.Subject,
-            validateOnChange: (key, parent, path) => {
-                return validateOnChange(key, parent, ["Subject", ...path]);
-            },
+            formProps: {
+                validateOnChange: (key, parent, path) => {
+                    return validateOnChange(key, parent, ["Subject", ...path]);
+                },
+            }
         }));
         document.body.append(modal);
     }

--- a/src/renderer/src/stories/pages/guided-mode/setup/GuidedSubjects.js
+++ b/src/renderer/src/stories/pages/guided-mode/setup/GuidedSubjects.js
@@ -89,7 +89,7 @@ export class GuidedSubjectsPage extends Page {
                 validateOnChange: (key, parent, path) => {
                     return validateOnChange(key, parent, ["Subject", ...path]);
                 },
-            }
+            },
         }));
         document.body.append(modal);
     }

--- a/src/renderer/src/stories/pages/uploads/UploadsPage.js
+++ b/src/renderer/src/stories/pages/uploads/UploadsPage.js
@@ -311,7 +311,7 @@ export class UploadsPage extends Page {
                     const value = parent[name];
                     if (name.includes("api_key")) return await validateDANDIApiKey(value, name.includes("staging"));
                 },
-            }
+            },
         }));
         document.body.append(modal);
     }

--- a/src/renderer/src/stories/pages/uploads/UploadsPage.js
+++ b/src/renderer/src/stories/pages/uploads/UploadsPage.js
@@ -73,7 +73,7 @@ export async function createDandiset(results = {}) {
                     ];
             }
         },
-        conditionalRequirements: [
+        groups: [
             {
                 name: "Embargo your Data",
                 properties: [["embargo_status"], ["nih_award_number"]],

--- a/src/renderer/src/stories/pages/uploads/UploadsPage.js
+++ b/src/renderer/src/stories/pages/uploads/UploadsPage.js
@@ -306,10 +306,12 @@ export class UploadsPage extends Page {
                 const input = this.form.getInput(["dandiset "]);
                 input.requestUpdate();
             },
-            validateOnChange: async (name, parent) => {
-                const value = parent[name];
-                if (name.includes("api_key")) return await validateDANDIApiKey(value, name.includes("staging"));
-            },
+            formProps: {
+                validateOnChange: async (name, parent) => {
+                    const value = parent[name];
+                    if (name.includes("api_key")) return await validateDANDIApiKey(value, name.includes("staging"));
+                },
+            }
         }));
         document.body.append(modal);
     }


### PR DESCRIPTION
Beyond #547, this PR implements the following changes as noted in @oruebel's user test:
1. Allow "Enter" to interact with the form, where this will jump to the next input (except in the case of lists, which will be jumped...)
2. Note that keywords should be provided one at a time
3. Allow arbitrary groupings similar to the Conditional Requirements (e.g. age and DOB) but without the linked validation
      - Implement the "Institutional Info" group with Institution and Lab together
4. Note DOI format (among others) for Related Publications
5. Show the full path of the field below the original label on the Metadata forms, so it's easy to tell what fields are linked to which higher-level properties (e.g. Virus now has NWBFile next to it)
6. Update Data Formats page to align with suggestions