### PR TITLE
Automatic chromatic deployment on PR approval

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v1
       - run: |
           echo "${{ github.event.action }}"
-          npm ci
+          # npm ci
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,13 +7,11 @@ on:
 
 jobs:
   test:
-    # if: github.event.action == 'workflow_dispatch' || (github.event.action == 'pull_request_review' && github.event.review.state == 'approved')
+    if: github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request_review' && github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: |
-          echo "${{ github.event_name }}"
-          # npm ci
+      - run: npm ci
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - run: |
-          echo "${{ github.event.action }}"
+          echo "${{ github.event_name }}"
           # npm ci
       - uses: chromaui/action@v1
         with:

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   test:
-    if: github.event.action == "workflow_dispatch" || (github.event.action == "pull_request_review" && github.event.review.state == "approved")
+    if: github.event.action == 'workflow_dispatch' || (github.event.action == 'pull_request_review' && github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -7,11 +7,13 @@ on:
 
 jobs:
   test:
-    if: github.event.action == 'workflow_dispatch' || (github.event.action == 'pull_request_review' && github.event.review.state == 'approved')
+    # if: github.event.action == 'workflow_dispatch' || (github.event.action == 'pull_request_review' && github.event.review.state == 'approved')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - run: npm ci
+      - run: |
+          echo "${{ github.event.action }}"
+          npm ci
       - uses: chromaui/action@v1
         with:
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,9 +1,13 @@
-name: "Chromatic Publish"
+name: Chromatic
 
-on: workflow_dispatch
+on:
+  workflow_dispatch:
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   test:
+    if: github.event.action == "workflow_dispatch" || (github.event.action == "pull_request_review" && github.event.review.state == "approved")
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1


### PR DESCRIPTION
Only running chromatic at the end of a PR (instead of every push) has really saved us a lot on monthly snapshots. Mildly annoying to have to trigger it manually, so trying out this trigger method on submission of an approved PR review