### PR TITLE
Allow Relative Video / Audio File Paths during NeuroConv Conversion

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -395,6 +395,13 @@ def convert_to_nwb(info: dict) -> str:
 
     resolved_output_path.parent.mkdir(exist_ok=True, parents=True)  # Ensure all parent directories exist
 
+
+    for interface_name, interface_class_name in info["interfaces"].items():
+        if (interface_class_name == 'VideoInterface' or interface_class_name == 'AudioInterface'):
+            interface_source_data = info["source_data"][interface_name]
+            interface_source_data["file_paths"] = list(map(lambda path: os.path.relpath(path, resolved_output_path), interface_source_data["file_paths"]))
+
+
     converter = instantiate_custom_converter(info["source_data"], info["interfaces"])
 
     def update_conversion_progress(**kwargs):


### PR DESCRIPTION
This is a follow-up PR to #452 that will allow us to determine how to allow relative video / audio file paths without breaking the ability for NeuroConv to discover those files in the first place.