### PR TITLE
Try pinning boto

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -21,3 +21,5 @@ dependencies:
       - dandi >= 0.58.1
       - pytest == 7.4.0
       - pytest-cov == 4.1.0
+      - boto3 < 1.34.12
+      - botocore < 1.34.12

--- a/environments/environment-MAC.yml
+++ b/environments/environment-MAC.yml
@@ -21,3 +21,5 @@ dependencies:
       - dandi >= 0.58.1
       - pytest == 7.4.0
       - pytest-cov == 4.1.0
+      - boto3 < 1.34.12
+      - botocore < 1.34.12


### PR DESCRIPTION
After analyzing differences between [passing](https://github.com/NeurodataWithoutBorders/nwb-guide/actions/runs/7399504355/job/20131089010) to [failing](https://github.com/NeurodataWithoutBorders/nwb-guide/actions/runs/7409596543/job/20160174711) environments as of 5 days ago, the only difference is `boto3` and `botocore` (the only package we use that cut a new release on Jan 5)

Who knows why that would trigger this specific issue, so perhaps a long shot, but trying here