### PR TITLE
Fix Bugs with New Application Structure

### DIFF
--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -129,7 +129,7 @@ const convertOldPath = (path) => {
 
 const transformProgressFile = (progressFile) => {
     progressFile["page-before-exit"] = convertOldPath(progressFile["page-before-exit"]);
-    Object.values(progressFile.sections).forEach((section) => {
+    Object.values(progressFile.sections ?? {}).forEach((section) => {
         const pages = {};
         Object.entries(section.pages).forEach(([page, value]) => {
             pages[convertOldPath(page)] = value;

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -120,10 +120,29 @@ export const getEntries = () => {
     return progressFiles.filter((path) => path.slice(-5) === ".json");
 };
 
+const oldConversionsPath = "conversion";
+const convertOldPath = (path) => {
+    if (path && path.slice(0, oldConversionsPath.length) === oldConversionsPath)return `/${path.slice(oldConversionsPath.length)}`;
+    else return path
+}
+
+const transformProgressFile = (progressFile) => {
+    progressFile["page-before-exit"] = convertOldPath(progressFile["page-before-exit"]);
+    Object.values(progressFile.sections).forEach((section) => {
+        const pages = {}
+        Object.entries(section.pages).forEach(([ page, value ]) => {
+            pages[convertOldPath(page)] = value
+        })
+        section.pages = pages
+    })
+
+    return progressFile
+
+}
 export const getAll = (progressFiles) => {
     return progressFiles.map((progressFile) => {
         let progressFilePath = joinPath(guidedProgressFilePath, progressFile);
-        return JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath));
+        return transformProgressFile(JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath)));
     });
 };
 
@@ -134,6 +153,7 @@ export const getCurrentProjectName = () => {
 
 export const get = (name) => {
     if (!name) {
+        console.error('No name provided to get()')
         const params = new URLSearchParams(location.search);
         const projectName = params.get("project");
         if (!projectName) {
@@ -155,18 +175,14 @@ export const get = (name) => {
     let progressFilePath = joinPath(guidedProgressFilePath, name + ".json");
 
     const exists = fs ? fs.existsSync(progressFilePath) : localStorage.getItem(progressFilePath) !== null;
-    return exists ? JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath)) : {};
+    return transformProgressFile(exists ? JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath)) : {});
 };
 
-const oldConversionsPath = "conversion";
 export function resume(name) {
     const global = this ? this.load(name) : get(name);
 
     let commandToResume = global["page-before-exit"] || "//start";
     updateURLParams({ project: name });
-
-    if (commandToResume.slice(0, oldConversionsPath.length) === oldConversionsPath)
-        commandToResume = `/${commandToResume.slice(oldConversionsPath.length)}`;
 
     if (this) this.onTransition(commandToResume);
 

--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -122,27 +122,29 @@ export const getEntries = () => {
 
 const oldConversionsPath = "conversion";
 const convertOldPath = (path) => {
-    if (path && path.slice(0, oldConversionsPath.length) === oldConversionsPath)return `/${path.slice(oldConversionsPath.length)}`;
-    else return path
-}
+    if (path && path.slice(0, oldConversionsPath.length) === oldConversionsPath)
+        return `/${path.slice(oldConversionsPath.length)}`;
+    else return path;
+};
 
 const transformProgressFile = (progressFile) => {
     progressFile["page-before-exit"] = convertOldPath(progressFile["page-before-exit"]);
     Object.values(progressFile.sections).forEach((section) => {
-        const pages = {}
-        Object.entries(section.pages).forEach(([ page, value ]) => {
-            pages[convertOldPath(page)] = value
-        })
-        section.pages = pages
-    })
+        const pages = {};
+        Object.entries(section.pages).forEach(([page, value]) => {
+            pages[convertOldPath(page)] = value;
+        });
+        section.pages = pages;
+    });
 
-    return progressFile
-
-}
+    return progressFile;
+};
 export const getAll = (progressFiles) => {
     return progressFiles.map((progressFile) => {
         let progressFilePath = joinPath(guidedProgressFilePath, progressFile);
-        return transformProgressFile(JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath)));
+        return transformProgressFile(
+            JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath))
+        );
     });
 };
 
@@ -153,7 +155,7 @@ export const getCurrentProjectName = () => {
 
 export const get = (name) => {
     if (!name) {
-        console.error('No name provided to get()')
+        console.error("No name provided to get()");
         const params = new URLSearchParams(location.search);
         const projectName = params.get("project");
         if (!projectName) {
@@ -175,7 +177,9 @@ export const get = (name) => {
     let progressFilePath = joinPath(guidedProgressFilePath, name + ".json");
 
     const exists = fs ? fs.existsSync(progressFilePath) : localStorage.getItem(progressFilePath) !== null;
-    return transformProgressFile(exists ? JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath)) : {});
+    return transformProgressFile(
+        exists ? JSON.parse(fs ? fs.readFileSync(progressFilePath) : localStorage.getItem(progressFilePath)) : {}
+    );
 };
 
 export function resume(name) {

--- a/src/renderer/src/progress/update.js
+++ b/src/renderer/src/progress/update.js
@@ -28,7 +28,7 @@ export const updateAppProgress = (
     dataOrProjectName = {},
     projectName = typeof dataOrProjectName === "string" ? dataOrProjectName : undefined
 ) => {
-    const transitionOffPipeline = pageId && pageId.slice(0, 2) !== '//'
+    const transitionOffPipeline = pageId && pageId.slice(0, 2) !== "//";
 
     if (transitionOffPipeline) {
         updateURLParams({ project: undefined });

--- a/src/renderer/src/progress/update.js
+++ b/src/renderer/src/progress/update.js
@@ -28,7 +28,7 @@ export const updateAppProgress = (
     dataOrProjectName = {},
     projectName = typeof dataOrProjectName === "string" ? dataOrProjectName : undefined
 ) => {
-    const transitionOffPipeline = pageId && pageId.split("/")[0] !== "conversion";
+    const transitionOffPipeline = pageId && pageId.slice(0, 2) !== '//'
 
     if (transitionOffPipeline) {
         updateURLParams({ project: undefined });


### PR DESCRIPTION
This PR fixes some bugs introduced in #555 as a result of the new URL structure of the GUIDE. 

Essentially, the correct trigger is used to detect when the user has left their pipeline, and saved Section information is replaced with new path keys so duplicate buttons do not appear on the sidebar of old pipelines.