### PR TITLE
Update readthedocs-sphinx-search

### DIFF
--- a/docs/requirements-rtd.txt
+++ b/docs/requirements-rtd.txt
@@ -3,5 +3,5 @@ jsonschema==3.2.0
 Jinja2<3.1
 sphinx==5.1.1
 pydata-sphinx-theme==0.14.1
-readthedocs-sphinx-search==0.1.0rc3
+readthedocs-sphinx-search==0.3.2
 sphinx-copybutton==0.5.0


### PR DESCRIPTION
I received an email from readthedocs about a [security vulnerability](https://github.com/readthedocs/readthedocs-sphinx-search/security/advisories/GHSA-xgfm-fjx6-62mj) on readthedocs-sphinx-search, suggesting we update to the latest version. I think this is unlikely to affect us, but we might as well try to upgrade, since the current pinned version is >3 years old and there have been a [few improvements and bug fixes](https://github.com/readthedocs/readthedocs-sphinx-search/blob/main/CHANGELOG.rst) since then.