### PR TITLE
Fix Search Dropdown Selection

### DIFF
--- a/src/renderer/src/stories/Search.js
+++ b/src/renderer/src/stories/Search.js
@@ -315,7 +315,7 @@ export class Search extends LitElement {
                     const listItemElement = document.createElement("li");
                     listItemElement.classList.add("option");
                     listItemElement.setAttribute("hidden", "");
-                    listItemElement.setAttribute("tabindex", -1)
+                    listItemElement.setAttribute("tabindex", -1);
                     if (option.keywords) listItemElement.setAttribute("data-keywords", JSON.stringify(option.keywords));
                     listItemElement.addEventListener("click", (clickEvent) => {
                         clickEvent.stopPropagation();
@@ -395,21 +395,21 @@ export class Search extends LitElement {
         ...this.headerStyles,
     })}>
       <input placeholder="Type here to search" value=${valueToDisplay} @click=${(clickEvent) => {
-        clickEvent.stopPropagation();
+          clickEvent.stopPropagation();
           if (this.listMode === "click") {
               const input = clickEvent.target.value;
               this.#populate(input);
           }
-      }} 
-      
+      }}
+
       @input=${(inputEvent) => {
           const input = inputEvent.target.value;
           this.#populate(input);
       }}
 
       @blur=${(blurEvent) => {
-        if (blurEvent.relatedTarget.classList.contains("option")) return;
-        this.submit()
+          if (blurEvent.relatedTarget.classList.contains("option")) return;
+          this.submit();
       }}
 
       ></input>

--- a/src/renderer/src/stories/Search.js
+++ b/src/renderer/src/stories/Search.js
@@ -315,9 +315,10 @@ export class Search extends LitElement {
                     const listItemElement = document.createElement("li");
                     listItemElement.classList.add("option");
                     listItemElement.setAttribute("hidden", "");
+                    listItemElement.setAttribute("tabindex", -1)
                     if (option.keywords) listItemElement.setAttribute("data-keywords", JSON.stringify(option.keywords));
-                    listItemElement.addEventListener("click", (ev) => {
-                        ev.stopPropagation();
+                    listItemElement.addEventListener("click", (clickEvent) => {
+                        clickEvent.stopPropagation();
                         this.#onSelect(option);
                     });
 
@@ -393,19 +394,22 @@ export class Search extends LitElement {
     <div class="header" style=${styleMap({
         ...this.headerStyles,
     })}>
-      <input placeholder="Type here to search" value=${valueToDisplay} @click=${(ev) => {
-          ev.stopPropagation();
+      <input placeholder="Type here to search" value=${valueToDisplay} @click=${(clickEvent) => {
+        clickEvent.stopPropagation();
           if (this.listMode === "click") {
-              const input = ev.target.value;
+              const input = clickEvent.target.value;
               this.#populate(input);
           }
-      }} @input=${(ev) => {
-          const input = ev.target.value;
+      }} 
+      
+      @input=${(inputEvent) => {
+          const input = inputEvent.target.value;
           this.#populate(input);
       }}
 
-      @blur=${(ev) => {
-          this.submit();
+      @blur=${(blurEvent) => {
+        if (blurEvent.relatedTarget.classList.contains("option")) return;
+        this.submit()
       }}
 
       ></input>


### PR DESCRIPTION
This PR fixes the user's ability to select matched elements of the Search list (e.g. global Species metadata on the Subject Metadata page).

Adding an `onblur` callback on #548 resulted in blocking the usual `onclick` event since `blur` events are primary. This is avoided by checking whether the associated target element is one of the list items that the user clicked on, allowing us to skip the `onblur` callback if this is the case.