### PR TITLE
Fix source data merge for conversions

### DIFF
--- a/src/renderer/src/stories/FileSystemSelector.js
+++ b/src/renderer/src/stories/FileSystemSelector.js
@@ -183,6 +183,7 @@ export class FilesystemSelector extends LitElement {
         const isMultipleTypes = Array.isArray(this.type);
         this.setAttribute("manytypes", isMultipleTypes);
         const isArray = Array.isArray(this.value);
+
         const len = isArray ? this.value.length : 0;
 
         if (isArray) {
@@ -251,7 +252,7 @@ export class FilesystemSelector extends LitElement {
                                         >`
                                   : ""}`}
                 </button>
-                ${this.multiple && this.value.length > 1
+                ${this.multiple && isArray && this.value.length > 1
                     ? new List({
                           items: this.value.map((v) => ({ value: v })),
                           editable: false,

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -264,7 +264,7 @@ export class JSONSchemaInput extends LitElement {
                 value: this.value,
                 onSelect: (paths) => {
                     const value = paths.length ? paths : undefined;
-                    this.#updateData(fullPath, value)
+                    this.#updateData(fullPath, value);
                 },
                 onChange: (filePath) => validateOnChange && this.#triggerValidation(name, path),
                 onThrow: (...args) => this.#onThrow(...args),

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -262,7 +262,10 @@ export class JSONSchemaInput extends LitElement {
             const filesystemSelectorElement = new FilesystemSelector({
                 type: format,
                 value: this.value,
-                onSelect: (filePath) => this.#updateData(fullPath, filePath),
+                onSelect: (paths) => {
+                    const value = paths.length ? paths : undefined;
+                    this.#updateData(fullPath, value)
+                },
                 onChange: (filePath) => validateOnChange && this.#triggerValidation(name, path),
                 onThrow: (...args) => this.#onThrow(...args),
                 dialogOptions: this.form?.dialogOptions,

--- a/src/renderer/src/stories/pages/Page.js
+++ b/src/renderer/src/stories/pages/Page.js
@@ -2,10 +2,10 @@ import { LitElement, html } from "lit";
 import { openProgressSwal, runConversion } from "./guided-mode/options/utils.js";
 import { get, save } from "../../progress/index.js";
 import { dismissNotification, notify } from "../../dependencies/globals.js";
-import { randomizeElements, mapSessions } from "./utils.js";
+import { randomizeElements, mapSessions, merge } from "./utils.js";
 
 import { ProgressBar } from "../ProgressBar";
-import { resolveResults } from "./guided-mode/data/utils.js";
+import { resolveMetadata } from "./guided-mode/data/utils.js";
 import Swal from "sweetalert2";
 
 export class Page extends LitElement {
@@ -187,12 +187,17 @@ export class Page extends LitElement {
             const { subject, session, globalState = this.info.globalState } = info;
             const file = `sub-${subject}/sub-${subject}_ses-${session}.nwb`;
 
-            const { conversion_output_folder, name } = globalState.project;
+            const { conversion_output_folder, name, SourceData } = globalState.project;
+
+            const sessionResults = globalState.results[subject][session]
+
+            const sourceDataCopy = structuredClone(sessionResults.source_data);
 
             // Resolve the correct session info from all of the metadata for this conversion
             const sessionInfo = {
-                ...globalState.results[subject][session],
-                metadata: resolveResults(subject, session, globalState),
+                ...sessionResults,
+                metadata: resolveMetadata(subject, session, globalState),
+                source_data: merge(SourceData, sourceDataCopy)
             };
 
             const result = await runConversion(

--- a/src/renderer/src/stories/pages/Page.js
+++ b/src/renderer/src/stories/pages/Page.js
@@ -189,7 +189,7 @@ export class Page extends LitElement {
 
             const { conversion_output_folder, name, SourceData } = globalState.project;
 
-            const sessionResults = globalState.results[subject][session]
+            const sessionResults = globalState.results[subject][session];
 
             const sourceDataCopy = structuredClone(sessionResults.source_data);
 
@@ -197,7 +197,7 @@ export class Page extends LitElement {
             const sessionInfo = {
                 ...sessionResults,
                 metadata: resolveMetadata(subject, session, globalState),
-                source_data: merge(SourceData, sourceDataCopy)
+                source_data: merge(SourceData, sourceDataCopy),
             };
 
             const result = await runConversion(

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -5,7 +5,7 @@ import { ManagedPage } from "./ManagedPage.js";
 import { Modal } from "../../../Modal";
 
 import { validateOnChange } from "../../../../validation/index.js";
-import { resolveGlobalOverrides, resolveResults } from "./utils.js";
+import { resolveGlobalOverrides, resolveMetadata } from "./utils.js";
 import Swal from "sweetalert2";
 import { SimpleTable } from "../../../SimpleTable.js";
 import { onThrow } from "../../../../errors";
@@ -143,7 +143,7 @@ export class GuidedMetadataPage extends ManagedPage {
             sortedProps.forEach((k) => (newElectrodeItemSchema[k] = ogElectrodeItemSchema[k]));
         }
 
-        resolveResults(subject, session, globalState);
+        resolveMetadata(subject, session, globalState);
 
         // Create the form
         const form = new JSONSchemaForm({

--- a/src/renderer/src/stories/pages/guided-mode/data/utils.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/utils.js
@@ -58,7 +58,7 @@ export function resolveProperties(properties = {}, target, globals = {}) {
 }
 
 // Explicitly resolve the results for a particular session (from both GUIDE-defined globals and the NWB Schema)
-export function resolveResults(subject, session, globalState) {
+export function resolveMetadata(subject, session, globalState) {
     const overrides = resolveGlobalOverrides(subject, globalState); // Unique per-subject (but not sessions)
     const metadata = globalState.results[subject][session].metadata;
     const results = structuredClone(metadata); // Copy the metadata results from the form


### PR DESCRIPTION
This PR fixes the behavior of the `runConversion` JavaScript function to merge the global source data with the session-specific source data. Previously, a global VideoInterface (or any other) would _not_ show up in all the sessions.