### PR TITLE
Add direct installation links

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -12,7 +12,7 @@ MacOS - Intel
 
 Download the `NWB-GUIDE-vX.Y.Z.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-0.0.13.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
 
-MacOS - M1 Silicon
+MacOS - Apple Silicon
 ------------------
 
 Download the `NWB-GUIDE-vX.Y.Z-arm64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-0.0.13-arm64.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -15,7 +15,7 @@ Download the `NWB-GUIDE-vX.Y.Z.dmg <https://github.com/NeurodataWithoutBorders/n
 MacOS - M1 Silicon
 ------------------
 
-Download the `NWB-GUIDE-vX.Y.Z-arm64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-Setup-0.0.13.exe>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
+Download the `NWB-GUIDE-vX.Y.Z-arm64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-0.0.13-arm64.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
 
 .. note::
    Some data formats can have issues using this build of the application. If you encounter errors when using a particular interface, try following the advanced :ref:`Developer Installation instructions<developer_installation>` instructions.

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -10,7 +10,7 @@ Download and run the `NWB-GUIDE-Setup-vX.Y.Z.exe <https://github.com/NeurodataWi
 MacOS - Intel
 -------------
 
-Download the `NWB-GUIDE-vX.Y.Z.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-Setup-0.0.13.exe>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
+Download the `NWB-GUIDE-vX.Y.Z.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-0.0.13.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
 
 MacOS - M1 Silicon
 ------------------

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -13,7 +13,7 @@ MacOS - Intel
 Download the `NWB-GUIDE-vX.Y.Z.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-0.0.13.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
 
 MacOS - Apple Silicon
-------------------
+---------------------
 
 Download the `NWB-GUIDE-vX.Y.Z-arm64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-0.0.13-arm64.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
 

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,20 +1,26 @@
 
 Installation
-===============
-
-Begin by downloading the latest release from the :releases:`GitHub release page <>`.
+============
 
 Windows
-----------------------
+-------
 
-Run the `setup.exe` file and follow all instructions.
+Download and run the `NWB-GUIDE-Setup-vX.Y.Z.exe <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-Setup-0.0.13.exe>`_ file and follow all instruction prompts.
 
-MacOS
----------------------------
+MacOS - Intel
+-------------
 
-Run the `.dmg` file and follow all instructions to move the file into your Applications folder.
+Download the `NWB-GUIDE-vX.Y.Z.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-Setup-0.0.13.exe>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
+
+MacOS - M1 Silicon
+------------------
+
+Download the `NWB-GUIDE-vX.Y.Z-arm64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-Setup-0.0.13.exe>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
+
+.. note::
+   Some data formats can have issues using this build of the application. If you encounter errors when using a particular interface, try following the advanced :ref:`Developer Installation instructions<developer_installation>` instructions.
 
 Ubuntu
----------------------------
+------
 
 Please clone the :linux-fix:`linux-fix <>` branch of the NWB GUIDE and follow the :ref:`Developer Installation instructions<developer_installation>` on this documentation after the "Clone the Repo" step.

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
   },
   "build": {
     "appId": "com.catalystneuro.nwbguide",
+    "artifactName": "NWB-GUIDE-${arch}.${ext}",
     "generateUpdatesFilesForAllChannels": true,
     "afterSign": "./notarize.js",
     "fileAssociations": [


### PR DESCRIPTION
fix #595 

Though, @garrettmflynn, is there a way you can remove the vX.Y.Z part from the file names? That's the only thing preventing us from using the `latest` tag and never having to update this to get it to work for latest releases (which I  just know is going to slip up one day)