### PR TITLE
Restore automation trigger

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -2,8 +2,8 @@ name: Chromatic
 
 on:
   workflow_dispatch:
-  #pull_request_review:
-  #  types: [submitted]
+  pull_request_review:
+    types: [submitted]
 
 jobs:
   test:


### PR DESCRIPTION
It seems the problem with chromatic baselines may actually have been due to the squashing rather than full merge of commits that I've been using on recent PR merges, rather than from the trigger condition

Enabling the full app according to Chromatic instructions appears to have fixed it