### PR TITLE
Update installation instructions

### DIFF
--- a/docs/developer_guide.rst
+++ b/docs/developer_guide.rst
@@ -24,7 +24,6 @@ Start by cloning the repository
 Install Python Dependencies
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-
 Install the appropriate Python dependencies for your operating system.
 
 **Windows**
@@ -51,6 +50,10 @@ Install the appropriate Python dependencies for your operating system.
 
     conda env create -f ./environments/environment-Linux.yml
 
+
+Activate the Python Environment
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
 Before starting NWB GUIDE, you'll need to ensure that the Python environment is activated.
 
 .. code-block:: bash
@@ -58,8 +61,8 @@ Before starting NWB GUIDE, you'll need to ensure that the Python environment is 
     conda activate nwb-guide
 
 
-Installing JavaScript Dependencies
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Install JavaScript Dependencies
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 Next, install all JavaScript dependencies based on the `package-lock.json` file.
 
@@ -76,7 +79,6 @@ You can now run the following command to start the application using Electron.
 .. code-block:: bash
 
     npm start
-
 
 
 Repo Structure

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -29,4 +29,3 @@ Please clone the :linux-fix:`linux-fix <>` branch of the NWB GUIDE and follow th
 
    git clone --branch linux-fix https://github.com/NeurodataWithoutBorders/nwb-guide
    cd nwb-guide
-

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -5,22 +5,28 @@ Installation
 Windows
 -------
 
-Download and run the `NWB-GUIDE-Setup-vX.Y.Z.exe <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-x64.exe>`_ file and follow all instruction prompts.
+Download and run `NWB-GUIDE-x64.exe <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-x64.exe>`_ and follow all instruction prompts.
 
 MacOS - Intel
 -------------
 
-Download the `NWB-GUIDE-vX.Y.Z.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-x64.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
+Download `NWB-GUIDE-x64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-x64.dmg>`_, which should prompt you to move it into your 'Applications' folder in order to run.
 
 MacOS - Apple Silicon
 ---------------------
 
-Download the `NWB-GUIDE-vX.Y.Z-arm64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-arm64.dmg>`_ file, which should prompt you to move it into your 'Applications' folder in order to run.
+Download `NWB-GUIDE-arm64.dmg <https://github.com/NeurodataWithoutBorders/nwb-guide/releases/latest/download/NWB-GUIDE-arm64.dmg>`_, which should prompt you to move it into your 'Applications' folder in order to run.
 
 .. note::
    Some data formats can have issues using this build of the application. If you encounter errors when using a particular interface, try following the advanced :ref:`Developer Installation instructions<developer_installation>` instructions.
 
-Ubuntu
-------
+Linux
+-----
 
-Please clone the :linux-fix:`linux-fix <>` branch of the NWB GUIDE and follow the :ref:`Developer Installation instructions<developer_installation>` on this documentation after the "Clone the Repo" step.
+Please clone the :linux-fix:`linux-fix <>` branch of the NWB GUIDE and follow the :ref:`Developer Installation instructions<developer_installation>` after the "Clone the Repo" step.
+
+.. code-block:: bash
+
+   git clone --branch linux-fix https://github.com/NeurodataWithoutBorders/nwb-guide.git
+   cd nwb-guide
+

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -27,6 +27,6 @@ Please clone the :linux-fix:`linux-fix <>` branch of the NWB GUIDE and follow th
 
 .. code-block:: bash
 
-   git clone --branch linux-fix https://github.com/NeurodataWithoutBorders/nwb-guide.git
+   git clone --branch linux-fix https://github.com/NeurodataWithoutBorders/nwb-guide
    cd nwb-guide
 


### PR DESCRIPTION
- Replace hyperlink text "NWB-GUIDE-Setup-vX.Y.Z.exe" (and similar) with the correct filename.
- Add example code to the linux instructions.
- Change Ubuntu -> Linux. It works on Fedora as well. I think we can generalize to all Linux systems and change this if someone reports it not working on their system.
- Update Dev instructions to make clear that activating the env is necessary regardless of which OS you use (currently it looks like it applies only to Linux)
 