### PR TITLE
Change Exit Pipeline Text

### DIFF
--- a/src/renderer/src/stories/Main.js
+++ b/src/renderer/src/stories/Main.js
@@ -101,7 +101,7 @@ export class Main extends LitElement {
                     footer = Object.assign(
                         {
                             exit: false,
-                            next: "Complete Pipeline",
+                            next: "Exit Pipeline",
                             onNext: () => this.toRender.page.to("/"),
                         },
                         footer && typeof footer === "object" ? footer : {}


### PR DESCRIPTION
fix #646

My intention with "Complete Pipeline" was to gesture at the completion of the GUIDE's conversion workflow (rather than simply leaving an ongoing conversion), though switching to "Exit Pipeline" is more consistent with the general exit message and simply changes the emphasis by moving where the button is.