### PR TITLE
Interactive electrodes

### DIFF
--- a/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -412,7 +412,6 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
             defs["Electrode"] = {
                 "type": "object",
                 "properties": new_electrodes_properties,
-                "additionalProperties": True,  # Allow for new columns
             }
 
     return json.loads(json.dumps(replace_nan_with_none(dict(results=metadata, schema=schema)), cls=NWBMetaDataEncoder))

--- a/src/renderer/src/stories/SimpleTable.js
+++ b/src/renderer/src/stories/SimpleTable.js
@@ -56,7 +56,10 @@ export class SimpleTable extends LitElement {
 
             :host([loading]) tfoot {
                 display: block;
-                position: relative;
+                position: absolute;
+                top: 50%;
+                left: 50%;
+                transform: translate(-50%, -50%);
             }
 
             :host([loading]) tfoot td {
@@ -102,6 +105,7 @@ export class SimpleTable extends LitElement {
             }
 
             .table-container {
+                position: relative;
                 overflow: auto;
                 max-height: 400px;
                 border: 1px solid gray;
@@ -579,10 +583,10 @@ export class SimpleTable extends LitElement {
 
         // Add cells to body after the initial table render
         const body = this.shadowRoot.querySelector("tbody");
-        body.innerHTML = ""; // Clear existing render
 
         if (!this.#loaded) {
             const tStart = performance.now();
+
             body.append(
                 ...Object.values(this.#cells).map((row) => {
                     const tr = document.createElement("tr");
@@ -635,6 +639,8 @@ export class SimpleTable extends LitElement {
             cells.forEach((c) => c.validate());
             this.#rendered(true);
         }
+
+        console.log(this)
     }
 
     #updateRows(row, nRows) {
@@ -879,6 +885,7 @@ export class SimpleTable extends LitElement {
     }
 
     render() {
+
         this.#updateRendered();
         this.#resetLoadState();
 

--- a/src/renderer/src/stories/SimpleTable.js
+++ b/src/renderer/src/stories/SimpleTable.js
@@ -640,7 +640,7 @@ export class SimpleTable extends LitElement {
             this.#rendered(true);
         }
 
-        console.log(this)
+        console.log(this);
     }
 
     #updateRows(row, nRows) {
@@ -885,7 +885,6 @@ export class SimpleTable extends LitElement {
     }
 
     render() {
-
         this.#updateRendered();
         this.#resetLoadState();
 

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -397,11 +397,8 @@ export class GuidedMetadataPage extends ManagedPage {
             renderTable: function (name, metadata, fullPath) {
                 const updatedSchema = structuredClone(metadata.schema);
                 metadata.schema = updatedSchema;
-
-                // NOTE: Handsontable will occasionally have a context menu that doesn't actually trigger any behaviors
-                if (name !== "Electrodes") return new SimpleTable(metadata);
-                else return true; // All other tables are handled by the default behavior
-                // if (name !== "ElectrodeColumns" && name !== "Electrodes") return new Table(metadata);
+                if (name === "Electrodes") metadata.deferLoading = true;
+                return new SimpleTable(metadata);
             },
             onThrow,
         });


### PR DESCRIPTION
Re-enable interactivity for ElectrodesTable to diagnose ongoing issues with on large tables.

If you want to avoid the deferred table rendering, simply comment out the following line in the GuidedMetadata.js file:
```javascript
if (name === "Electrodes") metadata.deferLoading = true
```

