### PR TITLE
Fix Standalone Validation Page

### DIFF
--- a/src/renderer/src/stories/pages/inspect/InspectPage.js
+++ b/src/renderer/src/stories/pages/inspect/InspectPage.js
@@ -93,6 +93,7 @@ export class InspectPage extends Page {
         schema: {
             type: "array",
             items: {
+                type: "string",
                 format: ["file", "directory"],
                 multiple: true,
             },


### PR DESCRIPTION
Merging #656 resulted in the inability to render the file selector for the standalone validation page.

This PR fixes that issue.