### PR TITLE
Fix nested input rendering

### DIFF
--- a/src/renderer/src/stories/Dashboard.js
+++ b/src/renderer/src/stories/Dashboard.js
@@ -241,7 +241,7 @@ export class Dashboard extends LitElement {
                 });
 
                 // Skip right over the page if configured as such
-                if (previous.info.previous === this.page) this.page.onTransition(-1);
+                if (previous && previous.info.previous === this.page) this.page.onTransition(-1);
                 else this.page.onTransition(1);
             }
         });

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -435,7 +435,7 @@ export class JSONSchemaForm extends LitElement {
         if (Array.isArray(name)) name = name.join("-"); // Convert array to string
         const parent = this.shadowRoot.querySelector(`#${encode(name)}`);
         if (!parent) return;
-        
+
         let container = parent.querySelector(`.${type}`);
 
         if (!container) {

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -101,6 +101,12 @@ const componentCSS = `
       width:100%;
     }
 
+    .form-section {
+        display: flex;
+        flex-direction: column;
+        gap: 10px;
+    }
+
     #empty {
         display: flex;
         align-items: center;
@@ -427,7 +433,15 @@ export class JSONSchemaForm extends LitElement {
 
     #addMessage = (name, message, type) => {
         if (Array.isArray(name)) name = name.join("-"); // Convert array to string
-        const container = this.shadowRoot.querySelector(`#${encode(name)} .${type}`);
+        const parent = this.shadowRoot.querySelector(`#${encode(name)}`);
+        let container = parent.querySelector(`.${type}`);
+
+        if (!container) {
+            container = document.createElement("div");
+            container.classList.add(type);
+            parent.append(container);
+        }
+
         const item = new InspectorListItem(message);
         container.appendChild(item);
     };
@@ -437,16 +451,16 @@ export class JSONSchemaForm extends LitElement {
 
         if (!localPath.length) return;
 
-        const container = this.shadowRoot.querySelector(`#${encode(localPath)} .${type}`);
+        const parent = this.shadowRoot.querySelector(`#${encode(localPath)}`);
+        const container = parent.querySelector(`.${type}`);
+        if (!container) return 
 
-        if (container) {
-            const nChildren = container.children.length;
-            container.innerHTML = "";
+        const nChildren = container.children.length;
+        container.innerHTML = "";
 
-            // Track errors and warnings
-            if (type === "errors") this.#nErrors -= nChildren;
-            if (type === "warnings") this.#nWarnings -= nChildren;
-        }
+        // Track errors and warnings
+        if (type === "errors") this.#nErrors -= nChildren;
+        if (type === "warnings") this.#nWarnings -= nChildren;
     };
 
     status;
@@ -668,9 +682,6 @@ export class JSONSchemaForm extends LitElement {
         return html`
             <div id=${encode(localPath.join("-"))} class="form-section">
                 ${interactiveInput}
-                <div class="errors"></div>
-                <div class="warnings"></div>
-                <div class="info"></div>
             </div>
         `;
     };

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -454,6 +454,8 @@ export class JSONSchemaForm extends LitElement {
         if (!localPath.length) return;
 
         const parent = this.shadowRoot.querySelector(`#${encode(localPath)}`);
+        if (!parent) return;
+
         const container = parent.querySelector(`.${type}`);
         if (!container) return;
 

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -453,7 +453,7 @@ export class JSONSchemaForm extends LitElement {
 
         const parent = this.shadowRoot.querySelector(`#${encode(localPath)}`);
         const container = parent.querySelector(`.${type}`);
-        if (!container) return 
+        if (!container) return;
 
         const nChildren = container.children.length;
         container.innerHTML = "";
@@ -679,11 +679,7 @@ export class JSONSchemaForm extends LitElement {
 
         this.inputs[localPath.join("-")] = interactiveInput;
 
-        return html`
-            <div id=${encode(localPath.join("-"))} class="form-section">
-                ${interactiveInput}
-            </div>
-        `;
+        return html` <div id=${encode(localPath.join("-"))} class="form-section">${interactiveInput}</div> `;
     };
 
     load = () => {

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -434,6 +434,8 @@ export class JSONSchemaForm extends LitElement {
     #addMessage = (name, message, type) => {
         if (Array.isArray(name)) name = name.join("-"); // Convert array to string
         const parent = this.shadowRoot.querySelector(`#${encode(name)}`);
+        if (!parent) return;
+        
         let container = parent.querySelector(`.${type}`);
 
         if (!container) {

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -361,9 +361,12 @@ export class JSONSchemaInput extends LitElement {
                 background: rgb(255, 229, 228) !important;
             }
 
+            jsonschema-input {
+                width: 100%;
+            }
+
             main {
                 display: flex;
-                margin-top: 0.5rem;
             }
 
             #controls {
@@ -425,7 +428,7 @@ export class JSONSchemaInput extends LitElement {
                 width: 100%;
                 padding-top: 4px;
                 color: dimgray !important;
-                margin: 0 0 1em;
+                margin: 0 0;
                 line-height: 1.4285em;
             }
 
@@ -449,6 +452,7 @@ export class JSONSchemaInput extends LitElement {
                 display: block;
                 width: 100%;
                 margin: 0;
+                margin-bottom: 10px;
                 color: black;
                 font-weight: 600;
                 font-size: 1.2em !important;
@@ -630,16 +634,14 @@ export class JSONSchemaInput extends LitElement {
                 }
                 </label>
                 <main>${input}${this.controls ? html`<div id="controls">${this.controls}</div>` : ""}</main>
-                <p class="guided--text-input-instructions">
-                    ${
-                        schema.description
-                            ? html`${unsafeHTML(capitalize(schema.description))}${schema.description.slice(-1)[0] ===
-                              "."
-                                  ? ""
-                                  : "."}`
-                            : ""
-                    }
-                </p>
+                ${
+                    schema.description
+                        ? html`<p class="guided--text-input-instructions">${unsafeHTML(capitalize(schema.description))}${schema.description.slice(-1)[0] ===
+                            "."
+                                ? ""
+                                : "."}</p>`
+                        : ""
+                }
             </div>
         `;
     }

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -636,10 +636,11 @@ export class JSONSchemaInput extends LitElement {
                 <main>${input}${this.controls ? html`<div id="controls">${this.controls}</div>` : ""}</main>
                 ${
                     schema.description
-                        ? html`<p class="guided--text-input-instructions">${unsafeHTML(capitalize(schema.description))}${schema.description.slice(-1)[0] ===
-                            "."
-                                ? ""
-                                : "."}</p>`
+                        ? html`<p class="guided--text-input-instructions">
+                              ${unsafeHTML(capitalize(schema.description))}${schema.description.slice(-1)[0] === "."
+                                  ? ""
+                                  : "."}
+                          </p>`
                         : ""
                 }
             </div>


### PR DESCRIPTION
This PR fixes a small rendering issue with the nested JSONSchemaInput properties (e.g. `file_paths` for the VideoInterface), which convert lists of only one element to single inputs.