### PR TITLE
Update Legend to Render Multi-Session View Well

### DIFF
--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
@@ -39,9 +39,9 @@ export class GuidedInspectorPage extends Page {
         this.style.height = "100%"; // Fix main section
 
         Object.assign(this.style, {
-            display: "flex",
-            flexDirection: "column",
-            justifyContent: "space-between",
+            display: "grid",
+            gridTemplateRows: "calc(100% - 120px) 1fr",
+            rowGap: "10px"
         });
     }
 
@@ -136,6 +136,7 @@ export class GuidedInspectorPage extends Page {
                         const items = this.report.messages;
 
                         const list = new InspectorList({ items, emptyMessage });
+
                         Object.assign(list.style, {
                             height: "100%",
                         });

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedInspectorPage.js
@@ -41,7 +41,7 @@ export class GuidedInspectorPage extends Page {
         Object.assign(this.style, {
             display: "grid",
             gridTemplateRows: "calc(100% - 120px) 1fr",
-            rowGap: "10px"
+            rowGap: "10px",
         });
     }
 


### PR DESCRIPTION
This PR fixes last-minute stylistic changes on #671 that caused the legend to be pushed down below the view window when the user was processing multiple sessions in Guided Mode.