### PR TITLE
Update validation tracking to show invalid without spamming with input errors

### DIFF
--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -225,7 +225,6 @@ document.addEventListener("dragover", (dragEvent) => {
     dragEvent.stopPropagation();
 });
 
-
 export class JSONSchemaForm extends LitElement {
     static get styles() {
         return css([componentCSS]);
@@ -942,9 +941,7 @@ export class JSONSchemaForm extends LitElement {
                             type: "warning",
                             missing: true,
                         });
-                    }
-                    else {
-
+                    } else {
                         const rowName = pathToValidate.slice(-1)[0];
                         const isRow = typeof rowName === "number";
 
@@ -1021,9 +1018,7 @@ export class JSONSchemaForm extends LitElement {
 
             return true;
         } else {
-
             if (this.validateEmptyValues) {
-
                 // Add new invalid classes and errors
                 input.classList.add("invalid");
 
@@ -1033,7 +1028,6 @@ export class JSONSchemaForm extends LitElement {
                     [...path, name]
                 );
 
-            
                 updatedErrors.forEach((info) => (onError ? "" : this.#addMessage(localPath, info, "errors")));
             }
             // element.title = errors.map((info) => info.message).join("\n"); // Set all errors to show on hover
@@ -1374,7 +1368,6 @@ export class JSONSchemaForm extends LitElement {
     };
 
     #registerRequirements = (schema, requirements = {}, acc = this.#requirements, path = []) => {
-        
         if (!schema) return;
 
         const isItem = (schema) => schema.items && schema.items.properties;
@@ -1420,7 +1413,6 @@ export class JSONSchemaForm extends LitElement {
     }
 
     render() {
-
         this.#updateRendered(); // Create a new promise to check on the rendered state
 
         this.#resetLoadState();
@@ -1434,7 +1426,7 @@ export class JSONSchemaForm extends LitElement {
 
         // // Delete extraneous results
         // this.#deleteExtraneousResults(this.results, this.schema);
-        this.#requirements = {}
+        this.#requirements = {};
         this.#registerRequirements(this.schema, this.required);
 
         return html`

--- a/src/renderer/src/stories/JSONSchemaInput.js
+++ b/src/renderer/src/stories/JSONSchemaInput.js
@@ -502,7 +502,8 @@ export class JSONSchemaInput extends LitElement {
     attributeChangedCallback(key, _, latest) {
         super.attributeChangedCallback(...arguments);
 
-        const formSchema = this.form.schema;
+        const formSchema = this.form?.schema;
+        if (!formSchema) return;
 
         if (key === "required") {
             const name = this.path.slice(-1)[0];

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -332,7 +332,8 @@ export class GuidedPathExpansionPage extends Page {
         }
 
         if (Object.keys(finalStructure).length === 0) {
-            const message = "Please configure at least one interface. <br/><small>Otherwise, revisit <b>Pipeline Workflow</b> to update your configuration.</small>";
+            const message =
+                "Please configure at least one interface. <br/><small>Otherwise, revisit <b>Pipeline Workflow</b> to update your configuration.</small>";
             this.#notification = this.notify(message, "error");
             throw message;
         }

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -20,6 +20,8 @@ import { header } from "../../../forms/utils";
 
 import autocompleteIcon from "../../../assets/inspect.svg?raw";
 
+const propOrder = ["path", "subject_id", "session_id"];
+
 export async function autocompleteFormatString(path) {
     let notification;
 
@@ -50,10 +52,8 @@ export async function autocompleteFormatString(path) {
     const content = document.createElement("div");
     Object.assign(content.style, {
         padding: "25px",
-        paddingBottom: "0px",
     });
 
-    const propOrder = ["path", "subject_id", "session_id"];
     const form = new JSONSchemaForm({
         validateEmptyValues: false,
         schema: {
@@ -331,6 +331,12 @@ export class GuidedPathExpansionPage extends Page {
             finalStructure[key] = entry;
         }
 
+        if (Object.keys(finalStructure).length === 0) {
+            const message = "Please configure at least one interface. <br/><small>Otherwise, revisit <b>Pipeline Workflow</b> to update your configuration.</small>";
+            this.#notification = this.notify(message, "error");
+            throw message;
+        }
+
         const results = await run(`locate`, finalStructure, { title: "Locating Data" }).catch((error) => {
             this.notify(error.message, "error");
             throw error;
@@ -438,7 +444,7 @@ export class GuidedPathExpansionPage extends Page {
         const form = (this.form = new JSONSchemaForm({
             ...structureState,
             onThrow,
-            validateEmptyValues: false,
+            validateEmptyValues: null,
 
             controls,
 

--- a/src/renderer/src/stories/pages/uploads/UploadsPage.js
+++ b/src/renderer/src/stories/pages/uploads/UploadsPage.js
@@ -52,7 +52,6 @@ export async function createDandiset(results = {}) {
     const content = document.createElement("div");
     Object.assign(content.style, {
         padding: "25px",
-        paddingBottom: "0px",
     });
 
     const updateNIHInput = (state) => {


### PR DESCRIPTION
This PR ensures that the form status (e.g. colored accents) are rendered appropriately without spamming the UI with input errors.

This is an improvement on Ben's suggestion to block validation until user interaction, which originally was not properly indicating when forms were invalid (at a high level) _before_ interaction. This was missed because we only used this feature on pop-up forms that were not showing this.

While this was discovered and tested on the Path Expansion page, it's actually more appropriate for that page to have _suggested requirements_ than interaction-based validation. So this was also updated in this PR.