### PR TITLE
Conversion Review File Button

### DIFF
--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -279,8 +279,9 @@ export class GuidedPathExpansionPage extends Page {
 
                 // Map existing results to new subject information (if available)
                 const existingResults = Object.values(Object.values(globalState.results ?? {})[0] ?? {})[0] ?? {};
+
                 const existingMetadata = existingResults.metadata;
-                const existingSourceData = existingResults.source_data;
+                const existingSourceData =existingResults.source_data;
 
                 const source_data = {};
                 for (let key in globalState.interfaces) {
@@ -350,6 +351,8 @@ export class GuidedPathExpansionPage extends Page {
             this.#notification = this.notify(message, "error");
             throw message;
         }
+
+        // globalState.results = {} // Clear existing results
 
         // Save an overall results object organized by subject and session
         merge({ results }, globalState);

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedPathExpansion.js
@@ -281,7 +281,7 @@ export class GuidedPathExpansionPage extends Page {
                 const existingResults = Object.values(Object.values(globalState.results ?? {})[0] ?? {})[0] ?? {};
 
                 const existingMetadata = existingResults.metadata;
-                const existingSourceData =existingResults.source_data;
+                const existingSourceData = existingResults.source_data;
 
                 const source_data = {};
                 for (let key in globalState.interfaces) {

--- a/src/renderer/src/stories/pages/guided-mode/results/GuidedResults.js
+++ b/src/renderer/src/stories/pages/guided-mode/results/GuidedResults.js
@@ -6,7 +6,6 @@ import { Page } from "../../Page.js";
 import { getStubArray } from "../options/GuidedStubPreview.js";
 import { getSharedPath } from "../../../preview/NWBFilePreview.js";
 
-
 import { electron, path } from "../../../../electron/index.js";
 const { ipcRenderer } = electron;
 
@@ -20,23 +19,19 @@ export class GuidedResultsPage extends Page {
             html`<nwb-button
                 size="small"
                 @click=${() => {
-                    if (ipcRenderer)
-                        ipcRenderer.send(
-                            "showItemInFolder",
-                            this.#sharedPath()
-                        );
+                    if (ipcRenderer) ipcRenderer.send("showItemInFolder", this.#sharedPath());
                 }}
                 >${unsafeSVG(folderOpenSVG)}</nwb-button
             >`,
-        }
+    };
 
     footer = {};
 
     #sharedPath = () => {
         const { conversion } = this.info.globalState;
-        if (!conversion) return '';
+        if (!conversion) return "";
         return getSharedPath(getStubArray(conversion).map((item) => item.file));
-    }
+    };
 
     updated() {
         this.save(); // Save the current state
@@ -48,11 +43,13 @@ export class GuidedResultsPage extends Page {
         if (!conversion)
             return html`<div style="text-align: center;"><p>Your conversion failed. Please try again.</p></div>`;
 
-
         return html`
             <p>Your data was successfully converted to NWB!</p>
             <ol style="margin: 10px 0px; padding-top: 0;">
-            ${getStubArray(conversion).map(({ file }) => file.split(path.sep).slice(-1)[0]).sort().map((id) => html`<li>${id}</li>`)}
+                ${getStubArray(conversion)
+                    .map(({ file }) => file.split(path.sep).slice(-1)[0])
+                    .sort()
+                    .map((id) => html`<li>${id}</li>`)}
             </ol>
         `;
     }


### PR DESCRIPTION
Added a folder button to the Conversion Review page as originally requested in #704, which allows for quickly accessing the shared path that contains the output files for this pipeline.

Also simplified the display of the output files, which might or might not be desired:
<img width="1392" alt="Screenshot 2024-03-27 at 11 05 54 AM" src="https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/27ce4ac7-c478-452b-9301-6bb74502d885">
