### PR TITLE
Allow Starting Generated Pipelines

### DIFF
--- a/src/renderer/src/progress/index.js
+++ b/src/renderer/src/progress/index.js
@@ -185,7 +185,7 @@ export const get = (name) => {
 export function resume(name) {
     const global = this ? this.load(name) : get(name);
 
-    let commandToResume = global["page-before-exit"] || "//start";
+    let commandToResume = global["page-before-exit"] || "//details";
     updateURLParams({ project: name });
 
     if (this) this.onTransition(commandToResume);


### PR DESCRIPTION
This PR allows you to "resume" the generated test pipelines immediately after creation.

After merging #731, users cannot start generated test files because pipelines without a specified `page-before-exit` would default to the removed `/start` page—and, since this page no longer exists, would be spit back to the Convert page.