### PR TITLE
Avoid needless selections and clear on transition

### DIFF
--- a/src/renderer/src/stories/Dashboard.js
+++ b/src/renderer/src/stories/Dashboard.js
@@ -202,6 +202,9 @@ export class Dashboard extends LitElement {
     }
 
     setMain(page) {
+
+        window.getSelection().empty() // Remove user selection before transitioning
+
         // Update Previous Page
         const info = page.info;
         const previous = this.page;
@@ -238,7 +241,9 @@ export class Dashboard extends LitElement {
             this.subSidebar.hide();
         }
 
+
         this.page.set(toPass, false);
+
 
         this.page.checkSyncState().then(() => {
             const projectName = info.globalState?.project?.name;
@@ -265,6 +270,7 @@ export class Dashboard extends LitElement {
                 if (previous && previous.info.previous === this.page) this.page.onTransition(-1);
                 else this.page.onTransition(1);
             }
+
         });
     }
 

--- a/src/renderer/src/stories/Dashboard.js
+++ b/src/renderer/src/stories/Dashboard.js
@@ -202,8 +202,7 @@ export class Dashboard extends LitElement {
     }
 
     setMain(page) {
-
-        window.getSelection().empty() // Remove user selection before transitioning
+        window.getSelection().empty(); // Remove user selection before transitioning
 
         // Update Previous Page
         const info = page.info;
@@ -241,9 +240,7 @@ export class Dashboard extends LitElement {
             this.subSidebar.hide();
         }
 
-
         this.page.set(toPass, false);
-
 
         this.page.checkSyncState().then(() => {
             const projectName = info.globalState?.project?.name;
@@ -270,7 +267,6 @@ export class Dashboard extends LitElement {
                 if (previous && previous.info.previous === this.page) this.page.onTransition(-1);
                 else this.page.onTransition(1);
             }
-
         });
     }
 

--- a/src/renderer/src/stories/table/Cell.ts
+++ b/src/renderer/src/stories/table/Cell.ts
@@ -219,8 +219,8 @@ export class TableCell extends LitElement {
         else if (this.schema.format === "date-time") {
             cls = DateTimeCell
             this.type = "date-time"
-        } 
-        
+        }
+
         else if (this.schema.type === "object") {
             cls = NestedInputCell
             this.type = "table"

--- a/src/renderer/src/stories/table/Cell.ts
+++ b/src/renderer/src/stories/table/Cell.ts
@@ -219,7 +219,9 @@ export class TableCell extends LitElement {
         else if (this.schema.format === "date-time") {
             cls = DateTimeCell
             this.type = "date-time"
-        } else if (this.schema.type === "object") {
+        } 
+        
+        else if (this.schema.type === "object") {
             cls = NestedInputCell
             this.type = "table"
         }

--- a/src/renderer/src/stories/table/cells/base.ts
+++ b/src/renderer/src/stories/table/cells/base.ts
@@ -201,17 +201,33 @@ export class TableCellBase extends LitElement {
 
     set(value: any, runOnChange = true) {
 
-        if (document.execCommand) {
+        // Ensure all operations are undoable
+        if (typeof InputEvent === 'function') {
             this.#editable.setAttribute('contenteditable', '')
             this.#editable.focus();
-            document.execCommand('selectAll');
-            document.execCommand('insertText', false, value);
+
+            const range = document.createRange();
+            range.selectNodeContents(this.#editable);
+            const sel = window.getSelection()!;
+            sel.removeAllRanges();
+            sel.addRange(range);
+
+            const inputEvent = new InputEvent('input', {
+                bubbles: true,
+                cancelable: false,
+                data: value,
+                inputType: 'insertText',
+            });
+            
+            this.#editable.dispatchEvent(inputEvent);
+            
             this.setText(value, undefined, runOnChange)
             this.#editable.blur();
             this.#editable.removeAttribute('contenteditable')
         }
 
-        else this.setText(value, undefined, runOnChange) // Ensure value is still set
+        
+        else this.setText(value, undefined, runOnChange) // Just set value
     }
 
     #render(property: 'renderer' | 'editor') {

--- a/src/renderer/src/stories/table/cells/base.ts
+++ b/src/renderer/src/stories/table/cells/base.ts
@@ -218,15 +218,15 @@ export class TableCellBase extends LitElement {
                 data: value,
                 inputType: 'insertText',
             });
-            
+
             this.#editable.dispatchEvent(inputEvent);
-            
+
             this.setText(value, undefined, runOnChange)
             this.#editable.blur();
             this.#editable.removeAttribute('contenteditable')
         }
 
-        
+
         else this.setText(value, undefined, runOnChange) // Just set value
     }
 

--- a/tests/e2e/workflow.ts
+++ b/tests/e2e/workflow.ts
@@ -379,7 +379,6 @@ export default async function runWorkflow(name, workflow, identifier) {
       const page = dashboard.page
       const firstSessionForm = page.forms[0].form
       firstSessionForm.accordions["NWBFile"].toggle(true)
-      window.getSelection().empty() // Remove annoying user-select highlight
     })
 
     await takeScreenshot(join(identifier, 'metadata-nwbfile'), 100)


### PR DESCRIPTION
fix #739 

Looks like this was caused by a deprecated command in `SimpleTable`, which selected the entire screen when it was supposed to select and inject text into a specific element. Updated to the latest browser features and it worked fine!