### PR TITLE
Limit updates to user interaction on tables

### DIFF
--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -1423,10 +1423,7 @@ export class JSONSchemaForm extends LitElement {
         if (this.#resolving) return this.#resolving;
         this.#resolving = resolve(this.#rendered, () => {
             const promise = Promise.all([...Object.values(this.forms), ...Object.values(this.tables)].map(({ rendered }) => rendered))
-            promise.then(() => {
-                this.#resolving = null;
-                console.error('DONE', this.base)
-            })
+            promise.then(() => this.#resolving = null)
             return promise
         }
         );

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -443,7 +443,7 @@ export class JSONSchemaForm extends LitElement {
                 isObject(value) && isObject(resolvedParent) ? merge(value, resolvedParent[name]) : value; // Merge with existing resolved values
         }
 
-        if (hasUpdate || forceUpdate) this.onUpdate(localPath, value); // Ensure the value has actually changed
+        if ((hasUpdate || forceUpdate)) this.onUpdate(localPath, value); // Ensure the value has actually changed
     }
 
     #addMessage = (name, message, type) => {
@@ -1417,12 +1417,20 @@ export class JSONSchemaForm extends LitElement {
         this.inputs = {};
     }
 
+    #resolving
     // Check if everything is internally rendered
     get rendered() {
-        const isRendered = resolve(this.#rendered, () =>
-            Promise.all([...Object.values(this.forms), ...Object.values(this.tables)].map(({ rendered }) => rendered))
+        if (this.#resolving) return this.#resolving;
+        this.#resolving = resolve(this.#rendered, () => {
+            const promise = Promise.all([...Object.values(this.forms), ...Object.values(this.tables)].map(({ rendered }) => rendered))
+            promise.then(() => {
+                this.#resolving = null;
+                console.error('DONE', this.base)
+            })
+            return promise
+        }
         );
-        return isRendered;
+        return this.#resolving;
     }
 
     render() {

--- a/src/renderer/src/stories/JSONSchemaForm.js
+++ b/src/renderer/src/stories/JSONSchemaForm.js
@@ -1422,11 +1422,12 @@ export class JSONSchemaForm extends LitElement {
     get rendered() {
         if (this.#resolving) return this.#resolving;
         this.#resolving = resolve(this.#rendered, () => {
-            const promise = Promise.all([...Object.values(this.forms), ...Object.values(this.tables)].map(({ rendered }) => rendered))
-            promise.then(() => this.#resolving = null)
-            return promise
-        }
-        );
+            const promise = Promise.all(
+                [...Object.values(this.forms), ...Object.values(this.tables)].map(({ rendered }) => rendered)
+            );
+            promise.then(() => (this.#resolving = null));
+            return promise;
+        });
         return this.#resolving;
     }
 

--- a/src/renderer/src/stories/SimpleTable.js
+++ b/src/renderer/src/stories/SimpleTable.js
@@ -877,7 +877,8 @@ export class SimpleTable extends LitElement {
                     }
                 }
 
-                this.#onCellChange(cell);
+                this.#onCellChange(cell); // Only update data if the value has changed
+
                 this.#checkStatus(); // Check status after every validation update
             },
         });

--- a/src/renderer/src/stories/pages/Page.js
+++ b/src/renderer/src/stories/pages/Page.js
@@ -137,6 +137,7 @@ export class Page extends LitElement {
         if (desyncedData) {
             delete desyncedData[key];
             if (Object.keys(desyncedData).length === 0) delete this.info.globalState.desyncedData;
+            await this.save({}, false)
         }
     }
 

--- a/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/renderer/src/stories/pages/guided-mode/data/GuidedMetadata.js
@@ -61,7 +61,6 @@ const tableRenderConfig = {
     },
     UnitColumns: function (metadata) {
         metadata.editable = false;
-        console.log("Column metadata", metadata);
         metadata.schema.description = "Update unit information directly on your source data.";
 
         return true;
@@ -184,12 +183,8 @@ export class GuidedMetadataPage extends ManagedPage {
     footer = {
         onNext: async () => {
             await this.save(); // Save in case the conversion fails
-
             for (let { form } of this.forms) await form.validate(); // Will throw an error in the callback
-
-            await this.convert({ preview: true });
-
-            return this.to(1);
+            return this.to(1); // Will trigger preview conversion if necessary
         },
     };
 
@@ -323,9 +318,7 @@ export class GuidedMetadataPage extends ManagedPage {
                 this.#checkAllLoaded();
             },
 
-            onUpdate: () => {
-                this.unsavedUpdates = "conversions";
-            },
+            onUpdate: () => (this.unsavedUpdates = "conversions"),
 
             validateOnChange,
             onlyRequired: false,

--- a/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
+++ b/src/renderer/src/stories/pages/guided-mode/options/GuidedStubPreview.js
@@ -40,10 +40,7 @@ export class GuidedStubPreviewPage extends Page {
         next: "Run Conversion",
         onNext: async () => {
             await this.save(); // Save in case the conversion fails
-
-            await this.convert();
-
-            return this.to(1);
+            return this.to(1); // Will trigger conversion if necessary
         },
     };
 

--- a/src/renderer/src/stories/table/Cell.ts
+++ b/src/renderer/src/stories/table/Cell.ts
@@ -16,7 +16,7 @@ type ValidationResult = {
 
 type ValidationFunction = (value: any) => any | any[]
 
-type OnValidateFunction = (info: ValidationResult) => void
+type OnValidateFunction = (info: ValidationResult, changed?: boolean) => void
 
 type TableCellProps = {
     value: string,

--- a/src/renderer/src/stories/table/cells/base.ts
+++ b/src/renderer/src/stories/table/cells/base.ts
@@ -98,7 +98,7 @@ export class TableCellBase extends LitElement {
         this.editable = editable
 
         this.#editable.addEventListener('input', (ev: InputEvent) => {
-            this.interacted = true
+            if (ev.isTrusted) this.interacted = true
             if (ev.inputType.includes('history')) this.setText(this.#editable.innerText) // Catch undo / redo}
         })
 
@@ -160,7 +160,6 @@ export class TableCellBase extends LitElement {
                 document.removeEventListener('click', this.#editableClose)
             } else {
                 current = this.#editor.value
-                console.log('Editor value', current)
                 this.interacted = true
                 if (this.#editor && this.#editor.onEditEnd) this.#editor.onEditEnd()
             }


### PR DESCRIPTION
This PR fixes a bug introduced with #741 to ensure that only user interactions trigger an `onUpdate` response. This is particularly relevant for auto-running preview and full conversions as needed.