### PR TITLE
Update mac workflows to use arm64 requirements

### DIFF
--- a/.github/workflows/Build-and-deploy-mac.yml
+++ b/.github/workflows/Build-and-deploy-mac.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: nwb-guide
-          environment-file: environments/environment-MAC.yml
+          environment-file: environments/environment-MAC-arm64.yml
           auto-activate-base: false
 
       - uses: actions/setup-node@v3

--- a/.github/workflows/Build-and-deploy-mac.yml
+++ b/.github/workflows/Build-and-deploy-mac.yml
@@ -1,5 +1,6 @@
 name: Mac Release
 run-name: ${{ github.actor }} is building a MAC release for NWB GUIDE
+# NOTE: even though the runner is an arm64 mac, both x64 and arm64 releases will be made
 
 on:
   workflow_dispatch:

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -37,7 +37,7 @@ jobs:
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-13  # Mac x64 runner
+            os: macos-12  # Mac x64 runner
             label: environments/environment-MAC.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -37,7 +37,7 @@ jobs:
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-13  # Mac x64 runner 
+            os: macos-13  # Mac x64 runner
             label: environments/environment-MAC.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -33,7 +33,7 @@ jobs:
 
           - python-version: "3.9"
             os: macos-latest
-            label: environments/environment-Mac.yml
+            label: environments/environment-MAC-arm64.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -32,12 +32,12 @@ jobs:
           #   prefix: /usr/share/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-latest
+            os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-arm64.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-13
+            os: macos-13  # Mac x64 runner 
             label: environments/environment-MAC.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -32,12 +32,12 @@ jobs:
           #   prefix: /usr/share/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-latest  # Mac arm64 runner
+            os: macos-latest-xlarge  # Mac arm64 runner
             label: environments/environment-MAC-arm64.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-12  # Mac x64 runner
+            os: macos-latest-large  # Mac x64 runner
             label: environments/environment-MAC.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -37,6 +37,11 @@ jobs:
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
+            os: macos-13
+            label: environments/environment-MAC.yml
+            prefix: /Users/runner/miniconda3/envs/nwb-guide
+
+          - python-version: "3.9"
             os: windows-latest
             label: environments/environment-Windows.yml
             prefix: C:\Miniconda3\envs\nwb-guide

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -32,13 +32,13 @@ jobs:
           #   prefix: /usr/share/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-latest-xlarge  # Mac arm64 runner
+            os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-arm64.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
-            os: macos-latest-large  # Mac x64 runner
-            label: environments/environment-MAC.yml
+            os: macos-13  # Mac x64 runner
+            label: environments/environment-MAC-arm64.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
@@ -49,6 +49,9 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: git fetch --prune --unshallow --tags
+
+      - name: Printout architecture
+        run: echo uname -m
 
       # see https://github.com/conda-incubator/setup-miniconda#caching-environments
       - name: Setup Mambaforge

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -51,7 +51,7 @@ jobs:
       - run: git fetch --prune --unshallow --tags
 
       - name: Printout architecture
-        run: echo uname -m
+        run: uname -m
 
       # see https://github.com/conda-incubator/setup-miniconda#caching-environments
       - name: Setup Mambaforge

--- a/.github/workflows/pyflask-build-and-dist-tests.yml
+++ b/.github/workflows/pyflask-build-and-dist-tests.yml
@@ -38,7 +38,7 @@ jobs:
 
           - python-version: "3.9"
             os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-arm64.yml
+            label: environments/environment-MAC.yml
             prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
@@ -89,7 +89,7 @@ jobs:
       - run: npm ci --verbose
 
       # fix for macos build
-      - if: matrix.os == 'macos-latest'
+      - if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
         run: rm -f /Users/runner/miniconda3/envs/nwb-guide/lib/python3.9/site-packages/sonpy/linux/sonpy.so
 
       - name: Build PyFlask distribution

--- a/.github/workflows/testing-live-services.yml
+++ b/.github/workflows/testing-live-services.yml
@@ -27,10 +27,10 @@ jobs:
           - os: ubuntu-latest
             label: environments/environment-Linux.yml
 
-          - os: macos-latest
+          - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-arm64.yml
 
-          - os: macos-13
+          - os: macos-13  # Mac x64 runner
             label: environments/environment-MAC.yml
 
           - os: windows-latest

--- a/.github/workflows/testing-live-services.yml
+++ b/.github/workflows/testing-live-services.yml
@@ -30,6 +30,9 @@ jobs:
           - os: macos-latest
             label: environments/environment-MAC-arm64.yml
 
+          - os: macos-13
+            label: environments/environment-MAC.yml
+
           - os: windows-latest
             label: environments/environment-Windows.yml
 

--- a/.github/workflows/testing-live-services.yml
+++ b/.github/workflows/testing-live-services.yml
@@ -28,7 +28,7 @@ jobs:
             label: environments/environment-Linux.yml
 
           - os: macos-latest
-            label: environments/environment-Mac.yml
+            label: environments/environment-MAC-arm64.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -27,10 +27,10 @@ jobs:
           - os: ubuntu-latest
             label: environments/environment-Linux.yml
 
-          - os: macos-latest
+          - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-arm64.yml
 
-          - os: macos-13
+          - os: macos-13  # Mac x64 runner
             label: environments/environment-MAC.yml
 
           - os: windows-latest

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -30,6 +30,9 @@ jobs:
           - os: macos-latest
             label: environments/environment-MAC-arm64.yml
 
+          - os: macos-13
+            label: environments/environment-MAC.yml
+
           - os: windows-latest
             label: environments/environment-Windows.yml
 

--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -28,7 +28,7 @@ jobs:
             label: environments/environment-Linux.yml
 
           - os: macos-latest
-            label: environments/environment-Mac.yml
+            label: environments/environment-MAC-arm64.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml


### PR DESCRIPTION
The GitHub Action `Build-and-deploy-mac.yml` is currently failing, possibly because on GitHub Actions, `os: macos-latest` now defaults to a M1 runner: https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories

Here, I updated the workflows to use `requirements-MAC-arm64.yml`

If we want to keep testing on a non-arm64 runner, we can pin to `os: macos-13` instead, or we can test on both arm64 and non-arm64.