### PR TITLE
Small Tests Improvements

### DIFF
--- a/tests/e2e/config.ts
+++ b/tests/e2e/config.ts
@@ -102,7 +102,7 @@ export const subjectInfo = {
   }
 }
 
-export const regenerateTestData = !existsSync(testDataRootPath) || false // Generate only if doesn't exist
+export const regenerateTestData = !existsSync(testDataPath) || !existsSync(testDatasetPath) || false // Generate only if doesn't exist
 // export const regenerateTestData = true // Force regeneration
 
 export const dandiInfo = {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -6,7 +6,7 @@ import { join } from 'node:path'
 
 import * as config from './config'
 import runWorkflow, { uploadToDandi } from './workflow'
-import { evaluate, takeScreenshot, to, toNextPage } from './utils'
+import { evaluate, takeScreenshot, to } from './utils'
 
 const x = 250 // Sidebar size
 const width = config.windowDims.width - x
@@ -152,7 +152,7 @@ describe('E2E Test', () => {
         await to('//conversion')
         await to('//upload')
 
-      })
+      }, 2000)
 
       uploadToDandi(subdirectory) // Upload to DANDI if the API key is provided
 

--- a/tests/e2e/workflow.ts
+++ b/tests/e2e/workflow.ts
@@ -4,7 +4,7 @@ import { sleep } from '../puppeteer'
 
 import { join } from 'node:path'
 import { evaluate, takeScreenshot, toNextPage } from "./utils"
-import { dandiInfo, publish, subjectInfo, testDatasetPath, testInterfaceInfo } from "./config"
+import { dandiInfo, publish, subjectInfo, testInterfaceInfo } from "./config"
 
 export const uploadToDandi = (subdirectory, forceSkip = false) => {
 


### PR DESCRIPTION
This PR ensures that test data is generated now that the new paths are provided. 

Additionally, this also introduces changes to stop rapidly (2s < 5min) in cases where certain cases where the E2E tests fail before DANDI Upload.