### PR TITLE
Move DANDI cleanup option to standalone page only

### DIFF
--- a/src/schemas/json/dandi/standalone.json
+++ b/src/schemas/json/dandi/standalone.json
@@ -10,6 +10,16 @@
                 "format": ["file", "directory"]
             },
             "minItems": 1
+        },
+        "additional_settings": {
+            "properties": {
+                "cleanup": {
+                    "type": "boolean",
+                    "title": "Cleanup Local Filesystem",
+                    "description": "Delete local files after upload",
+                    "default": false
+                }
+            }
         }
     },
     "required": ["filesystem_paths"]

--- a/src/schemas/json/dandi/upload.json
+++ b/src/schemas/json/dandi/upload.json
@@ -24,12 +24,6 @@
                     "type": "boolean",
                     "description": "Ignore the cache used by DANDI to speed up repeated operations.",
                     "default": false
-                },
-                "cleanup": {
-                    "type": "boolean",
-                    "title": "Cleanup Local Filesystem",
-                    "description": "Delete local files after upload",
-                    "default": false
                 }
             }
         }


### PR DESCRIPTION
This PR addresses a workflow issue discovered in the Dev Hackathon User Tests where enabling cleanup in Guided Mode deletes the conversion files, which are required on earlier pages of the pipeline and whose presence is tracked using a flag rather than explicit existence of the file paths.