### PR TITLE
Deemphasize Process Line of Quit Message 

### DIFF
--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -455,7 +455,8 @@ app.on("before-quit", async (ev: Event) => {
       type: "question",
       buttons: ["Yes", "No"],
       title: "Confirm",
-      message: "Any running process will be stopped. Are you sure you want to quit?",
+      message: 'Are you sure you want to quit?',
+      detail: 'Any running processes will be stopped.'
     })
 
     if (response !== 0) return // Skip quitting


### PR DESCRIPTION
This PR de-emphasizes the part of the Quit dialog that indicates active processes will be stopped. 

<img width="1392" alt="Screenshot 2024-05-29 at 1 54 04 PM" src="https://github.com/NeurodataWithoutBorders/nwb-guide/assets/46533749/1ef492b6-2a9a-4fc6-9fbf-8aeee5a1e0cb">

Based on feedback from the Dev Hackathon tests, this will hopefully reduce the frustration associated with this dialog if no active processes are open—as this is still useful to confirm the user would like to leave the GUIDE.