### PR TITLE
Fix Closing DANDI API Key Modal on Submission

### DIFF
--- a/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
+++ b/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
@@ -254,7 +254,7 @@ export class UploadsPage extends Page {
 
                 global.save();
                 await regenerateDandisets();
-                const input = this.form.getFormElement(["dandisets"]);
+                const input = this.form.getFormElement(["dandiset"]);
                 input.requestUpdate();
             },
             formProps: {

--- a/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
+++ b/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
@@ -256,7 +256,7 @@ export class UploadsPage extends Page {
                 regenerateDandisets().then(() => {
                     const input = this.form.getFormElement(["dandiset"]);
                     input.requestUpdate();
-                })
+                });
             },
             formProps: {
                 validateOnChange: async (name, parent) => {

--- a/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
+++ b/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
@@ -219,6 +219,7 @@ export class UploadsPage extends Page {
                 icon: keyIcon,
                 label: "API Keys",
                 onClick: () => {
+                    document.body.append(this.#globalModal)
                     this.#globalModal.form.results = structuredClone(global.data.DANDI?.api_keys ?? {});
                     this.#globalModal.open = true;
                 },

--- a/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
+++ b/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
@@ -253,9 +253,10 @@ export class UploadsPage extends Page {
                 merge(apiKeys, globalDandiData.api_keys);
 
                 global.save();
-                await regenerateDandisets();
-                const input = this.form.getFormElement(["dandiset"]);
-                input.requestUpdate();
+                regenerateDandisets().then(() => {
+                    const input = this.form.getFormElement(["dandiset"]);
+                    input.requestUpdate();
+                })
             },
             formProps: {
                 validateOnChange: async (name, parent) => {

--- a/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
+++ b/src/electron/frontend/core/components/pages/uploads/UploadsPage.js
@@ -219,7 +219,7 @@ export class UploadsPage extends Page {
                 icon: keyIcon,
                 label: "API Keys",
                 onClick: () => {
-                    document.body.append(this.#globalModal)
+                    document.body.append(this.#globalModal);
                     this.#globalModal.form.results = structuredClone(global.data.DANDI?.api_keys ?? {});
                     this.#globalModal.open = true;
                 },


### PR DESCRIPTION
This PR fixes an issue noted by Roland during the Conversion Workshop where you can't close the API Key window in Standalone Mode. 