### PR TITLE
Fix Validation with Timezone Awareness

### DIFF
--- a/src/electron/frontend/core/components/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/electron/frontend/core/components/pages/guided-mode/data/GuidedMetadata.js
@@ -279,6 +279,9 @@ export class GuidedMetadataPage extends ManagedPage {
 
         delete results.__generated; // Ignore generated results. NOTE: See if this fails
 
+
+        const pageThis = this;
+
         // Create the form
         const form = new JSONSchemaForm({
             identifier: instanceId,
@@ -333,7 +336,10 @@ export class GuidedMetadataPage extends ManagedPage {
 
             onUpdate: () => (this.unsavedUpdates = "conversions"),
 
-            validateOnChange: (...args) => validateOnChange.call(this, ...args),
+            validateOnChange: function (...args){
+                this.timezone = pageThis.workflow?.timezone.value; // Set the timezone for the form
+                return validateOnChange.call(this, ...args)
+            },
             onlyRequired: false,
             onStatusChange: (state) => this.manager.updateState(`sub-${subject}/ses-${session}`, state),
 

--- a/src/electron/frontend/core/components/pages/guided-mode/data/GuidedMetadata.js
+++ b/src/electron/frontend/core/components/pages/guided-mode/data/GuidedMetadata.js
@@ -279,7 +279,6 @@ export class GuidedMetadataPage extends ManagedPage {
 
         delete results.__generated; // Ignore generated results. NOTE: See if this fails
 
-
         const pageThis = this;
 
         // Create the form
@@ -336,9 +335,9 @@ export class GuidedMetadataPage extends ManagedPage {
 
             onUpdate: () => (this.unsavedUpdates = "conversions"),
 
-            validateOnChange: function (...args){
+            validateOnChange: function (...args) {
                 this.timezone = pageThis.workflow?.timezone.value; // Set the timezone for the form
-                return validateOnChange.call(this, ...args)
+                return validateOnChange.call(this, ...args);
             },
             onlyRequired: false,
             onStatusChange: (state) => this.manager.updateState(`sub-${subject}/ses-${session}`, state),

--- a/src/electron/frontend/core/components/pages/guided-mode/setup/GuidedSubjects.js
+++ b/src/electron/frontend/core/components/pages/guided-mode/setup/GuidedSubjects.js
@@ -102,6 +102,7 @@ export class GuidedSubjectsPage extends Page {
     connectedCallback() {
         super.connectedCallback();
 
+        const pageThis = this;
         const schema = preprocessMetadataSchema(undefined, true).properties.Subject;
 
         const modal = (this.#globalModal = createGlobalFormModal.call(this, {
@@ -110,7 +111,8 @@ export class GuidedSubjectsPage extends Page {
             validateEmptyValues: null,
             schema,
             formProps: {
-                validateOnChange: (localPath, parent, path) => {
+                validateOnChange: function (localPath, parent, path) {
+                    this.timezone = pageThis.workflow?.timezone?.value;
                     return validateOnChange.call(this, localPath, parent, ["Subject", ...path]);
                 },
             },

--- a/src/electron/frontend/core/validation/index.js
+++ b/src/electron/frontend/core/validation/index.js
@@ -68,7 +68,7 @@ export async function validateOnChange(name, parent, path, value) {
                 method: "POST",
                 headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
-                    timezone: this.workflow?.timezone?.value,
+                    timezone: this.timezone,
                     parent: copy,
                     function_name: resolvedFunctionName,
                 }),


### PR DESCRIPTION
This PR fixes an issue introduced in #820 where improperly setting the function `this` reference to access the timezone in the general `validateOnChange` function would result in the failure of complex validation steps like the inter-table validation expected on Ecephys tables.

Adjusting to always use `JSONSchemaForm` instances as the `this` value, and injecting a `timezone` property if necessary.

Since we're going through changes to our testing utilities, it's worth noting that _this would only have been detectable when using the File Metadata page itself_, which was why it wasn't flagged in the CI. We'll need to brainstorm ways to catch complex within-page issues like this in the future
