### PR TITLE
List individual errors when multiple are detected

### DIFF
--- a/src/electron/frontend/core/components/JSONSchemaForm.js
+++ b/src/electron/frontend/core/components/JSONSchemaForm.js
@@ -599,7 +599,7 @@ export class JSONSchemaForm extends LitElement {
         if (resolvedErrors.length) {
             const len = resolvedErrors.length;
             if (len === 1) this.throw(resolvedErrors[0].message);
-            else this.throw(`${len} JSON Schema errors detected.`);
+            else this.throw(`${len} errors detected: ${resolvedErrors.map((e) => e.message).join(" ")}`);
         }
 
         const allErrors = flaggedInputs


### PR DESCRIPTION
Fix #871.
The error used to say:
```
[sub-sub1/ses-ses1]: 2 JSON Schema errors detected.
```
Now it says:
```
[sub-sub1/ses-ses1]: 2 errors detected: Form requires property "sex". Form requires property "species".
```

It would be nicer to say `Subject form requires X`, but I believe the "Form requires" part comes from JSON schema so we would have to find and replace based on the source. That's more involved and I suggest it as a future enhancement.