### PR TITLE
Fix ndx_pose build

### DIFF
--- a/nwb-guide.spec
+++ b/nwb-guide.spec
@@ -45,7 +45,7 @@ tmp_ret = collect_all('tifffile')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 tmp_ret = collect_all('dlc2nwb')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
-tmp_ret = collect_all('ndx-pose')
+tmp_ret = collect_all('ndx_pose')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]
 tmp_ret = collect_all('tzdata')
 datas += tmp_ret[0]; binaries += tmp_ret[1]; hiddenimports += tmp_ret[2]


### PR DESCRIPTION
fix #875 

Very silly mistake; PyInstaller searches based on the name of the module, not the name of the package

This worked for me on a local build, we can check again on official v1.0.2 release when that's ready