### PR TITLE
Escape HTML tags in error messages on Source Data Information screen

### DIFF
--- a/src/electron/frontend/core/components/pages/guided-mode/data/GuidedSourceData.js
+++ b/src/electron/frontend/core/components/pages/guided-mode/data/GuidedSourceData.js
@@ -121,13 +121,14 @@ export class GuidedSourceDataPage extends ManagedPage {
 
                     if (result.message) {
                         const [type, ...splitText] = result.message.split(":");
+                        const escapedType = type.replaceAll("<", "&lt").replaceAll(">", "&gt");
                         const text = splitText.length
                             ? splitText.join(":").replaceAll("<", "&lt").replaceAll(">", "&gt")
                             : result.traceback
                               ? `<small><pre>${result.traceback.trim().split("\n").slice(-2)[0].trim()}</pre></small>`
                               : "";
 
-                        const message = `<h4 style="margin: 0;">Request Failed</h4><small>${type}</small><p>${text}</p>`;
+                        const message = `<h4 style="margin: 0;">Request Failed</h4><small>${escapedType}</small><p>${text}</p>`;
                         this.notify(message, "error");
                         throw result;
                     }


### PR DESCRIPTION
# Summary
On the Source Data Information screen, not all parts of error messages returned by the server are properly escaped.

# Example
Trying to select a Kilosort directory with an invalid `params.py` resulted in the following message:
> **Request Failed**
> invalid syntax (, line 3)

![Screenshot of error message](https://github.com/NeurodataWithoutBorders/nwb-guide/assets/166628128/e5c52c01-1b2f-4f89-876d-9e076ee28806)

The actual response from the server was:
```json
{"message": "invalid syntax (<string>, line 3)", "type": "SyntaxError"}
```

# Cause
While angle brackets in `text` are converted to HTML entities, `type` is left alone.
https://github.com/NeurodataWithoutBorders/nwb-guide/blob/29599c137dce1b49c9fdcb149c204cc88db7e7cf/src/electron/frontend/core/components/pages/guided-mode/data/GuidedSourceData.js#L123-L130

# Fix
Performing the same replacements on `type` should resolve this.

I have not tested this change, as I don't have an appropriate environment set up right now.