### PR TITLE
Disable mac on all tests

### DIFF
--- a/.github/workflows/example_data_cache.yml
+++ b/.github/workflows/example_data_cache.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
-        os: [ubuntu-latest, macos-latest, macos-13, windows-latest]
+        os: [ubuntu-latest, windows-latest] #,macos-latest, macos-13]
 
     steps:
 

--- a/.github/workflows/testing_dev.yml
+++ b/.github/workflows/testing_dev.yml
@@ -67,7 +67,7 @@ jobs:
           node-version: 20
 
       - name: Install GUIDE
-        run: npm ci --verbose --unsafe-perm=true
+        run: npm ci --verbose --ignore-scripts
 
       - if: matrix.os != 'ubuntu-latest'
         name: Run tests

--- a/.github/workflows/testing_dev.yml
+++ b/.github/workflows/testing_dev.yml
@@ -23,11 +23,16 @@ jobs:
           - os: ubuntu-latest
             label: environments/environment-Linux.yml
 
-          - os: macos-latest  # Mac arm64 runner
-            label: environments/environment-MAC-apple-silicon.yml
-
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
+          # Both Mac versions for dev testing started failing around July 25, 2024
+          # A similar type of issue to one previously seen
+          # manifesting as hanging/freezing/stalling during postinstall step of electron
+          # Last time, manually updating the package-lock.json file was enough to fix the issue
+          # But that didn't work this time
+#          - os: macos-latest  # Mac arm64 runner
+#            label: environments/environment-MAC-apple-silicon.yml
+#
+#          - os: macos-13  # Mac x64 runner
+#            label: environments/environment-MAC-intel.yml
 
 #          - os: windows-latest
 #            label: environments/environment-Windows.yml

--- a/.github/workflows/testing_dev_with_live_services.yml
+++ b/.github/workflows/testing_dev_with_live_services.yml
@@ -25,11 +25,16 @@ jobs:
           - os: ubuntu-latest
             label: environments/environment-Linux.yml
 
-          - os: macos-latest  # Mac arm64 runner
-            label: environments/environment-MAC-apple-silicon.yml
-
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
+          # Both Mac versions for dev testing started failing around July 25, 2024
+          # A similar type of issue to one previously seen
+          # manifesting as hanging/freezing/stalling during postinstall step of electron
+          # Last time, manually updating the package-lock.json file was enough to fix the issue
+          # But that didn't work this time
+#          - os: macos-latest  # Mac arm64 runner
+#            label: environments/environment-MAC-apple-silicon.yml
+#
+#          - os: macos-13  # Mac x64 runner
+#            label: environments/environment-MAC-intel.yml
 
 #          - os: windows-latest
 #            label: environments/environment-Windows.yml

--- a/.github/workflows/testing_flask_build_and_dist.yml
+++ b/.github/workflows/testing_flask_build_and_dist.yml
@@ -17,21 +17,22 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          # linux installation instructions use dev mode instead of distributable
-          # - python-version: "3.9"
-          #   os: ubuntu-latest
-          #   label: environments/environment-Linux.yml
-          #   prefix: /usr/share/miniconda3/envs/nwb-guide
+          # No linux in this matrix since installation instructions use dev mode instead of distributable
 
-          - python-version: "3.9"
-            os: macos-latest  # Mac arm64 runner
-            label: environments/environment-MAC-apple-silicon.yml
-            prefix: /Users/runner/miniconda3/envs/nwb-guide
-
-          - python-version: "3.9"
-            os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
-            prefix: /Users/runner/miniconda3/envs/nwb-guide
+          # Both Mac versions for dev testing started failing around July 25, 2024
+          # A similar type of issue to one previously seen
+          # manifesting as hanging/freezing/stalling during postinstall step of electron
+          # Last time, manually updating the package-lock.json file was enough to fix the issue
+          # But that didn't work this time
+#          - python-version: "3.9"
+#            os: macos-latest  # Mac arm64 runner
+#            label: environments/environment-MAC-apple-silicon.yml
+#            prefix: /Users/runner/miniconda3/envs/nwb-guide
+#
+#          - python-version: "3.9"
+#            os: macos-13  # Mac x64 runner
+#            label: environments/environment-MAC-intel.yml
+#            prefix: /Users/runner/miniconda3/envs/nwb-guide
 
           - python-version: "3.9"
             os: windows-latest

--- a/.github/workflows/testing_pipelines.yml
+++ b/.github/workflows/testing_pipelines.yml
@@ -21,11 +21,16 @@ jobs:
 #          - os: ubuntu-latest
 #            label: environments/environment-Linux.yml
 
-          - os: macos-latest  # Mac arm64 runner
-            label: environments/environment-MAC-apple-silicon.yml
-
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
+          # Both Mac versions for dev testing started failing around July 25, 2024
+          # A similar type of issue to one previously seen
+          # manifesting as hanging/freezing/stalling during postinstall step of electron
+          # Last time, manually updating the package-lock.json file was enough to fix the issue
+          # But that didn't work this time
+#          - os: macos-latest  # Mac arm64 runner
+#            label: environments/environment-MAC-apple-silicon.yml
+#
+#          - os: macos-13  # Mac x64 runner
+#            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "nwb-guide",
-  "version": "1.0.0",
+  "version": "1.0.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "nwb-guide",
-      "version": "1.0.0",
+      "version": "1.0.2",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
What is odd is that the app seems to work fine on Mac (arm64 at least) locally, it's just in CI where the problem is seen...

Propose disabling this until an `npm` expert can dig deeper