### PR TITLE
Simplify backend dependencies

### DIFF
--- a/.github/workflows/testing_dev.yml
+++ b/.github/workflows/testing_dev.yml
@@ -74,6 +74,9 @@ jobs:
       - name: Install GUIDE
         run: npm ci --verbose
 
+      - name: Install testing dependencies
+        run: pip install pytest pytest-cov
+
       - if: matrix.os != 'ubuntu-latest'
         name: Run tests
         run: npm run test:coverage

--- a/.github/workflows/testing_dev.yml
+++ b/.github/workflows/testing_dev.yml
@@ -78,7 +78,7 @@ jobs:
         run: pip install pytest pytest-cov
 
       - name: Manually remove matplotlib
-        run: pip uninstall matplotlib
+        run: pip uninstall matplotlib --yes
 
       - if: matrix.os != 'ubuntu-latest'
         name: Run tests

--- a/.github/workflows/testing_dev.yml
+++ b/.github/workflows/testing_dev.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Install testing dependencies
         run: pip install pytest pytest-cov
 
+      - name: Manually remove matplotlib
+        run: pip uninstall matplotlib
+
       - if: matrix.os != 'ubuntu-latest'
         name: Run tests
         run: npm run test:coverage

--- a/.github/workflows/testing_dev_with_live_services.yml
+++ b/.github/workflows/testing_dev_with_live_services.yml
@@ -79,6 +79,9 @@ jobs:
       - name: Install testing dependencies
         run: pip install pytest pytest-cov
 
+      - name: Manually remove matplotlib
+        run: pip uninstall matplotlib
+
       - name: Create env file
         run: |
           touch .env

--- a/.github/workflows/testing_dev_with_live_services.yml
+++ b/.github/workflows/testing_dev_with_live_services.yml
@@ -80,7 +80,7 @@ jobs:
         run: pip install pytest pytest-cov
 
       - name: Manually remove matplotlib
-        run: pip uninstall matplotlib
+        run: pip uninstall matplotlib --yes
 
       - name: Create env file
         run: |

--- a/.github/workflows/testing_dev_with_live_services.yml
+++ b/.github/workflows/testing_dev_with_live_services.yml
@@ -76,6 +76,9 @@ jobs:
       - name: Install GUIDE
         run: npm ci --verbose
 
+      - name: Install testing dependencies
+        run: pip install pytest pytest-cov
+
       - name: Create env file
         run: |
           touch .env

--- a/.github/workflows/testing_flask_build_and_dist.yml
+++ b/.github/workflows/testing_flask_build_and_dist.yml
@@ -85,6 +85,9 @@ jobs:
       - name: Install testing dependencies
         run: pip install pytest pytest-cov
 
+      - name: Manually remove matplotlib
+        run: pip uninstall matplotlib
+
       # Fix for macos build - remove bad sonpy file
       - if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
         run: rm -f "$CONDA_PREFIX/lib/python3.9/site-packages/sonpy/linux/sonpy.so"

--- a/.github/workflows/testing_flask_build_and_dist.yml
+++ b/.github/workflows/testing_flask_build_and_dist.yml
@@ -86,7 +86,7 @@ jobs:
         run: pip install pytest pytest-cov
 
       - name: Manually remove matplotlib
-        run: pip uninstall matplotlib
+        run: pip uninstall matplotlib --yes
 
       # Fix for macos build - remove bad sonpy file
       - if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'

--- a/.github/workflows/testing_flask_build_and_dist.yml
+++ b/.github/workflows/testing_flask_build_and_dist.yml
@@ -79,7 +79,11 @@ jobs:
         with:
           node-version: "20"
 
-      - run: npm ci --verbose
+      - name: Install GUIDE
+        run: npm ci --verbose
+
+      - name: Install testing dependencies
+        run: pip install pytest pytest-cov
 
       # Fix for macos build - remove bad sonpy file
       - if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'

--- a/.github/workflows/testing_pipelines.yml
+++ b/.github/workflows/testing_pipelines.yml
@@ -72,6 +72,9 @@ jobs:
       - name: Install GUIDE
         run: npm ci --verbose
 
+      - name: Install testing dependencies
+        run: pip install pytest pytest-cov
+
       # Load example data caches
       - name: Get ephy_testing_data current head hash
         id: ephys

--- a/.github/workflows/testing_pipelines.yml
+++ b/.github/workflows/testing_pipelines.yml
@@ -75,6 +75,9 @@ jobs:
       - name: Install testing dependencies
         run: pip install pytest pytest-cov
 
+      - name: Manually remove matplotlib
+        run: pip uninstall matplotlib
+
       # Load example data caches
       - name: Get ephy_testing_data current head hash
         id: ephys

--- a/.github/workflows/testing_pipelines.yml
+++ b/.github/workflows/testing_pipelines.yml
@@ -76,7 +76,7 @@ jobs:
         run: pip install pytest pytest-cov
 
       - name: Manually remove matplotlib
-        run: pip uninstall matplotlib
+        run: pip uninstall matplotlib --yes
 
       # Load example data caches
       - name: Get ephy_testing_data current head hash

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,10 +15,7 @@ dependencies:
       - flask == 2.3.2
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
-      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[full]
-      - dandi >= 0.60.0
-      - pytest == 7.4.0
-      - pytest-cov == 4.1.0
-      - scikit-learn == 1.4.0
-      - tqdm_publisher >= 0.0.1
-      - tzlocal >= 5.2
+      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
+      - scikit-learn == 1.4.0  # Tutorial data generation
+      - tqdm_publisher >= 0.0.1  # Progress bars
+      - tzlocal >= 5.2  # Frontend timezone handling

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -5,13 +5,13 @@ channels:
 dependencies:
   - python = 3.9.18
   - nodejs = 18.16.1
+  # Install these from conda-forge so that dependent packages get included in the distributable
   - numcodecs = 0.11.0
-  - lxml = 4.9.3  # pypi build fails due to x64/arm64 mismatch so install from conda-forge
-  - pyedflib = 0.1.32  # pypi build fails due to x64/arm64 mismatch so install from conda-forge
-  - numpy  # may have x64/arm64 mismatch issues so install from conda-forge
-  - pytables = 3.8 # pypi build fails on arm64 so install from conda-forge (used by neuroconv deps)
-  # install these from conda-forge so that dependent packages get included in the distributable
-  - jsonschema = 4.18.0  # installs jsonschema-specifications
+  - lxml = 4.9.3  # PyPI build fails due to x64/arm64 mismatch so install from conda-forge
+  - pyedflib = 0.1.32  # PyPI build fails due to x64/arm64 mismatch so install from conda-forge
+  - numpy  # May have x64/arm64 mismatch issues so install from conda-forge
+  - pytables = 3.8 # PyPI build fails on arm64 so install from conda-forge (used by neuroconv deps)
+  - jsonschema = 4.18.0  # Also installs jsonschema-specifications
   - pip
   - pip:
       - setuptools==70.0.0
@@ -21,12 +21,9 @@ dependencies:
       - flask == 2.3.2
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
-      # NOTE: the neuroconv wheel on pypi includes sonpy which is not compatible with arm64, so build and install
-      # neuroconv from github, which will remove the sonpy dependency when building from mac arm64
-      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[full]
-      - dandi >= 0.60.0
-      - pytest == 7.4.0
-      - pytest-cov == 4.1.0
-      - scikit-learn == 1.4.0
-      - tqdm_publisher >= 0.0.1
-      - tzlocal >= 5.2
+      # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
+      # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
+      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
+      - scikit-learn == 1.4.0  # Tutorial data generation
+      - tqdm_publisher >= 0.0.1  # Progress bars
+      - tzlocal >= 5.2  # Frontend timezone handling

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,10 +18,7 @@ dependencies:
       - flask == 2.3.2
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
-      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[full]
-      - dandi >= 0.60.0
-      - pytest == 7.4.0
-      - pytest-cov == 4.1.0
-      - scikit-learn == 1.4.0
-      - tqdm_publisher >= 0.0.1
-      - tzlocal >= 5.2
+      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
+      - scikit-learn == 1.4.0  # Tutorial data generation
+      - tqdm_publisher >= 0.0.1  # Progress bars
+      - tzlocal >= 5.2  # Frontend timezone handling

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask == 2.3.2
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
-      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[full]
+      - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
       - dandi >= 0.60.0
       - pytest == 7.2.2
       - pytest-cov == 4.1.0

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -19,9 +19,6 @@ dependencies:
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
       - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@main#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
-      - dandi >= 0.60.0
-      - pytest == 7.2.2
-      - pytest-cov == 4.1.0
-      - scikit-learn == 1.4.0
-      - tqdm_publisher >= 0.0.1
-      - tzlocal >= 5.2
+      - scikit-learn == 1.4.0  # Tutorial data generation
+      - tqdm_publisher >= 0.0.1  # Progress bars
+      - tzlocal >= 5.2  # Frontend timezone handling


### PR DESCRIPTION
Build tests just started failing due to a new hidden library in `matplotlib`, which we shouldn't even need as far as I know to run GUIDE (I tried removing locally and ran through a bunch of pipelines, including tutorial generation, and everything worked fine)

I think `spikeinterface[qualitymetrics]` in `neuroconv[testing]` (a part of `neuroconv[full]`) might be the source of that, so testing if this simplifies things

In the same spirit, there is no reason to bundle `pytest` or `pytest-cov` with our actual official build releases, so I'm suggesting only installing it in the CI where it is needed to run tests