### PR TITLE
Debug windows e2e tests

### DIFF
--- a/tests/e2e/puppeteer.ts
+++ b/tests/e2e/puppeteer.ts
@@ -52,7 +52,7 @@ export const connect = () => {
     });
 
     const browserURL = `http://localhost:${electronDebugPort}`
-    const browser = output.browser = await puppeteer.launch({ headless: 'new', protocolTimeout: launchProtocolTimeout})
+    const browser = output.browser = await puppeteer.launch({ headless: 'new', protocolTimeout: launchProtocolTimeout, dumpio: true})
     const page = output.page = await browser.newPage();
     await page.goto(browserURL);
     const endpoint = await page.evaluate(() => fetch(`json/version`).then(res => res.json()).then(res => res.webSocketDebuggerUrl))

--- a/tests/e2e/puppeteer.ts
+++ b/tests/e2e/puppeteer.ts
@@ -52,9 +52,10 @@ export const connect = () => {
     });
 
     const browserURL = `http://localhost:${electronDebugPort}`
-    const browser = output.browser = await puppeteer.launch({ headless: 'new', protocolTimeout: launchProtocolTimeout, dumpio: true})
+    const browser = output.browser = await puppeteer.launch({ headless: 'new', timeout: launchProtocolTimeout, protocolTimeout: launchProtocolTimeout, dumpio: true})
     const page = output.page = await browser.newPage();
     await page.goto(browserURL);
+    page.setDefaultTimeout(launchProtocolTimeout);
     const endpoint = await page.evaluate(() => fetch(`json/version`).then(res => res.json()).then(res => res.webSocketDebuggerUrl))
     await browser.close()
     delete output.browser

--- a/tests/e2e/puppeteer.ts
+++ b/tests/e2e/puppeteer.ts
@@ -34,7 +34,7 @@ type BrowserTestOutput = {
 }
 
 const beforeStartTimeout = 60 * 1000 // Wait for 1 minute for Electron to open (mostly for Windows)
-const launchProtocolTimeout = 6 * 60 * 1000 // Creating the test dataset can take up to 6 minutes (mostly for Windows)
+const launchProtocolTimeout = 10 * 60 * 1000 // Creating the test dataset can take up to 10 minutes (mostly for Windows)
 
 export const connect = () => {
 

--- a/tests/e2e/puppeteer.ts
+++ b/tests/e2e/puppeteer.ts
@@ -22,7 +22,7 @@ const beforeStart = (timeout) => new Promise(async (resolve, reject) => {
   process.stdout.on('data', handleOutput);
   process.stderr.on('data', handleOutput);
   process.on('close', (code) => console.log(`[electron] Exited with code ${code}`));
-  await sleep(timeout) // Wait for five seconds for Electron to open
+  await sleep(timeout)
 
   reject('Failed to open Electron window successfully.')
 })
@@ -33,14 +33,12 @@ type BrowserTestOutput = {
   browser?: puppeteer.Browser,
 }
 
-const beforeStartTimeout = 60 * 1000 // Wait for 1 minute for Electron to open (mostly for Windows)
+const beforeStartTimeout = 2 * 60 * 1000 // Wait 2 minutes for Electron to open
 const protocolTimeout = 10 * 60 * 1000 // Creating the test dataset can take up to 10 minutes (mostly for Windows)
 
 export const connect = () => {
 
-
   const output: BrowserTestOutput = {}
-
 
   beforeAll(async () => {
 
@@ -52,7 +50,7 @@ export const connect = () => {
     });
 
     const browserURL = `http://localhost:${electronDebugPort}`
-    const browser = output.browser = await puppeteer.launch({ headless: 'new'})
+    const browser = output.browser = await puppeteer.launch({ headless: 'new' })
     const page = output.page = await browser.newPage();
     await page.goto(browserURL);
     const endpoint = await page.evaluate(() => fetch(`json/version`).then(res => res.json()).then(res => res.webSocketDebuggerUrl))

--- a/tests/e2e/puppeteer.ts
+++ b/tests/e2e/puppeteer.ts
@@ -34,7 +34,7 @@ type BrowserTestOutput = {
 }
 
 const beforeStartTimeout = 60 * 1000 // Wait for 1 minute for Electron to open (mostly for Windows)
-const launchProtocolTimeout = 10 * 60 * 1000 // Creating the test dataset can take up to 10 minutes (mostly for Windows)
+const protocolTimeout = 10 * 60 * 1000 // Creating the test dataset can take up to 10 minutes (mostly for Windows)
 
 export const connect = () => {
 
@@ -52,7 +52,7 @@ export const connect = () => {
     });
 
     const browserURL = `http://localhost:${electronDebugPort}`
-    const browser = output.browser = await puppeteer.launch({ headless: 'new', timeout: launchProtocolTimeout, protocolTimeout: launchProtocolTimeout, dumpio: true})
+    const browser = output.browser = await puppeteer.launch({ headless: 'new'})
     const page = output.page = await browser.newPage();
     await page.goto(browserURL);
     const endpoint = await page.evaluate(() => fetch(`json/version`).then(res => res.json()).then(res => res.webSocketDebuggerUrl))
@@ -62,11 +62,10 @@ export const connect = () => {
 
     // Connect to browser WS Endpoint
     const browserWSEndpoint = endpoint.replace('localhost', '0.0.0.0')
-    output.browser = await puppeteer.connect({ browserWSEndpoint, defaultViewport: null, protocolTimeout: launchProtocolTimeout})
+    output.browser = await puppeteer.connect({ browserWSEndpoint, defaultViewport: null, protocolTimeout: protocolTimeout})
 
     const pages = await output.browser.pages()
     output.page = pages[0]
-    output.page.setDefaultTimeout(launchProtocolTimeout);
 
   }, beforeStartTimeout + 1000)
 

--- a/tests/e2e/puppeteer.ts
+++ b/tests/e2e/puppeteer.ts
@@ -55,7 +55,6 @@ export const connect = () => {
     const browser = output.browser = await puppeteer.launch({ headless: 'new', timeout: launchProtocolTimeout, protocolTimeout: launchProtocolTimeout, dumpio: true})
     const page = output.page = await browser.newPage();
     await page.goto(browserURL);
-    page.setDefaultTimeout(launchProtocolTimeout);
     const endpoint = await page.evaluate(() => fetch(`json/version`).then(res => res.json()).then(res => res.webSocketDebuggerUrl))
     await browser.close()
     delete output.browser
@@ -63,10 +62,11 @@ export const connect = () => {
 
     // Connect to browser WS Endpoint
     const browserWSEndpoint = endpoint.replace('localhost', '0.0.0.0')
-    output.browser = await puppeteer.connect({ browserWSEndpoint, defaultViewport: null })
+    output.browser = await puppeteer.connect({ browserWSEndpoint, defaultViewport: null, protocolTimeout: launchProtocolTimeout})
 
     const pages = await output.browser.pages()
     output.page = pages[0]
+    output.page.setDefaultTimeout(launchProtocolTimeout);
 
   }, beforeStartTimeout + 1000)
 

--- a/tests/e2e/tutorial.test.ts
+++ b/tests/e2e/tutorial.test.ts
@@ -37,6 +37,7 @@ describe('E2E Test', () => {
   const datasetTestFunction = config.regenerateTestData ? test : test.skip
 
   // Wait up to 10 minutes for dataset generation
+  // Both the test timeout and the protocolTimeout on puppeteer.connect() must be set to 10 min
   datasetTestFunction('Create tutorial dataset', { timeout: 10 * 60 * 1000 }, async () => {
 
     await evaluate(async () => {

--- a/tests/e2e/tutorial.test.ts
+++ b/tests/e2e/tutorial.test.ts
@@ -54,7 +54,7 @@ describe('E2E Test', () => {
     const outputLocation = await evaluate(async () => {
       const dashboard = document.querySelector('nwb-dashboard')
       const page = dashboard.page
-      const outputLocation = await page.generateTestData()
+      const outputLocation = await page.waitForResponse(page.generateTestData())
       page.requestUpdate()
       return outputLocation
     })

--- a/tests/e2e/tutorial.test.ts
+++ b/tests/e2e/tutorial.test.ts
@@ -37,7 +37,7 @@ describe('E2E Test', () => {
   const datasetTestFunction = config.regenerateTestData ? test : test.skip
 
   // Wait up to 10 minutes for dataset generation
-  datasetTestFunction('Create tutorial dataset', { timeout: 10 * 10 * 1000 }, async () => {
+  datasetTestFunction('Create tutorial dataset', { timeout: 10 * 60 * 1000 }, async () => {
 
     await evaluate(async () => {
 

--- a/tests/e2e/tutorial.test.ts
+++ b/tests/e2e/tutorial.test.ts
@@ -36,7 +36,8 @@ describe('E2E Test', () => {
 
   const datasetTestFunction = config.regenerateTestData ? test : test.skip
 
-  datasetTestFunction('Create tutorial dataset', async () => {
+  // Wait up to 10 minutes for dataset generation
+  datasetTestFunction('Create tutorial dataset', { timeout: 10 * 10 * 1000 }, async () => {
 
     await evaluate(async () => {
 
@@ -57,7 +58,7 @@ describe('E2E Test', () => {
       const outputLocation = await page.generateTestData()
       page.requestUpdate()
       return outputLocation
-    }, { timeout: 6 * 10 * 1000 }) // Wait up to 6 minutes for dataset generation
+    })
 
     // Take image after dataset generation
     await takeScreenshot('dataset-created', 500, { clip: datasetScreenshotClip })

--- a/tests/e2e/tutorial.test.ts
+++ b/tests/e2e/tutorial.test.ts
@@ -54,10 +54,10 @@ describe('E2E Test', () => {
     const outputLocation = await evaluate(async () => {
       const dashboard = document.querySelector('nwb-dashboard')
       const page = dashboard.page
-      const outputLocation = await page.waitForResponse(page.generateTestData())
+      const outputLocation = await page.generateTestData()
       page.requestUpdate()
       return outputLocation
-    })
+    }, { timeout: 6 * 10 * 1000 }) // Wait up to 6 minutes for dataset generation
 
     // Take image after dataset generation
     await takeScreenshot('dataset-created', 500, { clip: datasetScreenshotClip })


### PR DESCRIPTION
I thought we had fixed it. I think the core issue is on Windows, generating the test data takes longer than ~3 minutes and the process times out.

See https://github.com/NeurodataWithoutBorders/nwb-guide/actions/runs/10527059741/job/29169359993#step:13:484
and https://github.com/NeurodataWithoutBorders/nwb-guide/actions/runs/10527059741/job/29169359993#step:13:611

The last PCA output shows:
```
stdout | tests/e2e/tutorial.test.ts > E2E Test > Run through several pipeline workflows > Complete a multi-session workflow > Specify data formats
[electron] 
Fitting PCA:  58%|#####8    | 29/50 [02:54<02:52,  8.22s/it]
```

After that it says:
```
stdout | tests/e2e/tutorial.test.ts
[electron] [2024-08-23 14:12:59,405] INFO in app: Shutting down server
```
and
```
 FAIL  tests/e2e/tutorial.test.ts > E2E Test > Create tutorial dataset
ProtocolError: Runtime.callFunctionOn timed out. Increase the 'protocolTimeout' setting in launch/connect calls for a higher timeout if needed.
 ❯ Callback.<instance_members_initializer> node_modules/puppeteer-core/src/common/CallbackRegistry.ts:114:12
 ❯ new Callback node_modules/puppeteer-core/src/common/CallbackRegistry.ts:119:3
 ❯ CallbackRegistry.create node_modules/puppeteer-core/src/common/CallbackRegistry.ts:27:22
 ❯ Connection._rawSend node_modules/puppeteer-core/src/cdp/Connection.ts:125:22
 ❯ CdpCDPSession.send node_modules/puppeteer-core/src/cdp/CDPSession.ts:95:29
 ❯ ExecutionContext.#evaluate node_modules/puppeteer-core/src/cdp/ExecutionContext.ts:417:44
 ❯ ExecutionContext.evaluate node_modules/puppeteer-core/src/cdp/ExecutionContext.ts:292:32
 ❯ IsolatedWorld.evaluate node_modules/puppeteer-core/src/cdp/IsolatedWorld.ts:194:26
 ❯ CdpFrame.evaluate node_modules/puppeteer-core/src/api/Frame.ts:484:35
 ❯ CdpFrame.<anonymous> node_modules/puppeteer-core/src/util/decorators.ts:63:21
```