### PR TITLE
Update daily failure email list

### DIFF
--- a/.github/workflows/daily_tests.yml
+++ b/.github/workflows/daily_tests.yml
@@ -53,6 +53,6 @@ jobs:
           username: ${{ secrets.MAIL_USERNAME }}
           password: ${{ secrets.MAIL_PASSWORD }}
           subject: NWB GUIDE Daily Test Failure
-          to: cody.c.baker.phd@gmail.com,rly@lbl.gov
+          to: ${{  secrets.DAILY_FAILURE_EMAIL_LIST  }}
           from: NWB Guide Daily Tests
           body: "The daily tests workflow failed, please check the status at https://github.com/NeurodataWithoutBorders/nwb-guide/actions/workflows/daily_tests.yml"


### PR DESCRIPTION
Switches to using the github secret for email notifications of daily tests failing.