### PR TITLE
Extend timeout for generating tutorial dataset

### DIFF
--- a/tests/e2e/puppeteer.ts
+++ b/tests/e2e/puppeteer.ts
@@ -34,7 +34,7 @@ type BrowserTestOutput = {
 }
 
 const beforeStartTimeout = 2 * 60 * 1000 // Wait 2 minutes for Electron to open
-const protocolTimeout = 10 * 60 * 1000 // Creating the test dataset can take up to 10 minutes (mostly for Windows)
+const protocolTimeout = 15 * 60 * 1000 // Creating the test dataset can take up to 15 minutes (mostly for Windows)
 
 export const connect = () => {
 

--- a/tests/e2e/tutorial.test.ts
+++ b/tests/e2e/tutorial.test.ts
@@ -38,7 +38,7 @@ describe('E2E Test', () => {
 
   // Wait up to 10 minutes for dataset generation
   // Both the test timeout and the protocolTimeout on puppeteer.connect() must be set to 10 min
-  datasetTestFunction('Create tutorial dataset', { timeout: 10 * 60 * 1000 }, async () => {
+  datasetTestFunction('Create tutorial dataset', { timeout: 15 * 60 * 1000 }, async () => {
 
     await evaluate(async () => {
 


### PR DESCRIPTION
Windows e2e tests still fail occasionally due to a timeout when generating the tutorial dataset:
https://github.com/NeurodataWithoutBorders/nwb-guide/actions/runs/10973148072/job/30471309438

This PR extends the timeout from 10 minutes to 15 minutes.