### PR TITLE
Quick fix for werkzeug/flask incompatibility

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,6 +15,7 @@ dependencies:
       - flask == 2.3.2
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
+      - werkzeug < 3.0  # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # For stability, NeuroConv is pinned at a commit just prior to breaking SpikeInterface compatibility
       - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@fa636458aa5c321f1c2c08f6e682b4a52d5a83f3#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
       # For stability, pinning SpikeInterface to a version that works with NeuroConv and with tutorial generation

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -21,6 +21,7 @@ dependencies:
       - flask == 2.3.2
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
+      - werkzeug < 3.0  # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
       # For stability, NeuroConv is pinned at a commit just prior to breaking SpikeInterface compatibility

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,6 +18,7 @@ dependencies:
       - flask == 2.3.2
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
+      - werkzeug < 3.0  # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # For stability, NeuroConv is pinned at a commit just prior to breaking SpikeInterface compatibility
       - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@fa636458aa5c321f1c2c08f6e682b4a52d5a83f3#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
       # For stability, pinning SpikeInterface to a version that works with NeuroConv and with tutorial generation

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,6 +18,7 @@ dependencies:
       - flask == 2.3.2
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
+      - werkzeug < 3.0  # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # For stability, NeuroConv is pinned at a commit just prior to breaking SpikeInterface compatibility
       - neuroconv @ git+https://github.com/catalystneuro/neuroconv.git@fa636458aa5c321f1c2c08f6e682b4a52d5a83f3#neuroconv[dandi,compressors,ecephys,ophys,behavior,text]
       # For stability, pinning SpikeInterface to a version that works with NeuroConv and with tutorial generation


### PR DESCRIPTION
Most GitHub Actions are failing because flask depends on werkzeug, and werkzeug 3.0+ is being installed which deprecates the `__version__` attribute used by flask 2.3.2. We could upgrade flask to 3.0+, but that is a major change that will require some time to carefully test. While that happens, I suggest we pin werkzeug < 3.0.