### PR TITLE
Update env to use the latest nwbinspector, prepare 1.0.5 release

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -5,10 +5,16 @@
         "preferred": false
     },
     {
+        "name": "1.0.5",
+        "version": "v1.0.5",
+        "url": "https://nwb-guide.readthedocs.io/en/v1.0.5/",
+        "preferred": true
+    },
+    {
         "name": "1.0.4",
         "version": "v1.0.4",
         "url": "https://nwb-guide.readthedocs.io/en/v1.0.4/",
-        "preferred": true
+        "preferred": false
     },
     {
         "name": "1.0.3",

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -24,5 +24,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c
+      - nwbinspector==0.6.2
       - tables

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -24,5 +24,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector==0.6.1
+      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c
       - tables

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -32,4 +32,4 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c
+      - nwbinspector==0.6.2

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -32,4 +32,4 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector==0.6.1
+      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -27,5 +27,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c
+      - nwbinspector==0.6.2
       - tables

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -27,5 +27,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector==0.6.1
+      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c
       - tables

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -27,5 +27,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c
+      - nwbinspector==0.6.2
       - tables

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -27,5 +27,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector==0.6.1
+      - nwbinspector @ git+https://github.com/NeurodataWithoutBorders/nwbinspector.git@33ca3732efc8dc4c5fc99b58e978deb15e0bfe6c
       - tables

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nwb-guide",
   "productName": "NWB GUIDE",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "description": "NWB GUIDE is a desktop app that provides a no-code user interface for converting neurophysiology data to NWB.",
   "main": "./build/main/index.js",
   "engine": {


### PR DESCRIPTION
The latest nwbinspector removes the s3fs dependency which makes it possible to use the latest version of dandi/dandi-schema. This should fix #953.

Before merging, a new release of nwbinspector (0.6.2) should be made and we should pin to that instead of this particular commit.
Edit: I released nwbinspector 0.6.2 today and updated the pin here.

After merging, tag and release `v1.0.5` and write release notes on github.