### PR TITLE
Revert 'Update version to 1.0.6' temporarily

### DIFF
--- a/docs/_static/switcher.json
+++ b/docs/_static/switcher.json
@@ -5,16 +5,10 @@
         "preferred": false
     },
     {
-        "name": "1.0.6",
-        "version": "v1.0.6",
-        "url": "https://nwb-guide.readthedocs.io/en/v1.0.6/",
-        "preferred": true
-    },
-    {
         "name": "1.0.5",
         "version": "v1.0.5",
         "url": "https://nwb-guide.readthedocs.io/en/v1.0.5/",
-        "preferred": false
+        "preferred": true
     },
     {
         "name": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "nwb-guide",
   "productName": "NWB GUIDE",
-  "version": "1.0.6",
+  "version": "1.0.6-beta",
   "description": "NWB GUIDE is a desktop app that provides a no-code user interface for converting neurophysiology data to NWB.",
   "main": "./build/main/index.js",
   "engine": {


### PR DESCRIPTION
Do not release 1.0.6 right before the Cosyne tutorial. Bumping the version without release confuses what version the docs page says is the latest. So revert the version bump and release next week instead.