### PR TITLE
Pin dandi to 0.70.0 to address dev instance name change

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -16,6 +16,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - dandi == 0.70.0 # 0.71.0 requires instance="dandi-sandbox" which is not supported by neuroconv 0.6.1
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -24,6 +24,7 @@ dependencies:
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - dandi == 0.70.0 # 0.71.0 requires instance="dandi-sandbox" which is not supported by neuroconv 0.6.1
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -19,6 +19,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - dandi == 0.70.0 # 0.71.0 requires instance="dandi-sandbox" which is not supported by neuroconv 0.6.1
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -19,6 +19,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - dandi == 0.70.0 # 0.71.0 requires instance="dandi-sandbox" which is not supported by neuroconv 0.6.1
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars


### PR DESCRIPTION
Fix #1019. These lines should be removed when neuroconv supports the latest version of dandi and GUIDE supports that version of neuroconv. OR this can be removed if dandi re-allows `instance="dandi-staging"`.