### PR TITLE
Fix DANDI sandbox upload broken by dandi-cli 0.73.2

### DIFF
--- a/src/electron/frontend/assets/css/nativize.css
+++ b/src/electron/frontend/assets/css/nativize.css
@@ -38,13 +38,11 @@ a {
 /* New window (target) + external links */
 a[target],
 a[href^="https://"],
-a[href^="http://"]
-{
+a[href^="http://"] {
     border-bottom: 1px solid;
 }
 /* For YouTube Video links */
-a[href^="https://www.youtube.com"]
-{
+a[href^="https://www.youtube.com"] {
     border-bottom: 0px solid;
 }
 

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1387,7 +1387,6 @@ def upload_project_to_dandi(
     from neuroconv.tools.data_transfers import automatic_dandi_upload
 
     # CONVERSION_SAVE_FOLDER_PATH.mkdir(exist_ok=True, parents=True)  # Ensure base directory exists
-
     # Set API key env var for both old (< 0.73.2) and new dandi versions
     os.environ["DANDI_API_KEY"] = api_key
     if sandbox:


### PR DESCRIPTION
## Summary
- **Root cause**: [dandi-cli 0.73.2](https://github.com/dandi/dandi-cli/pull/1731) (released Nov 15, 2025) changed API key env var lookup from the generic `DANDI_API_KEY` to instance-specific vars (e.g. `DANDI_SANDBOX_API_KEY` for the sandbox). NWB GUIDE only set `DANDI_API_KEY`, so sandbox uploads silently failed (timeout after 5 min).
- **Impact**: All E2E DANDI upload tests have been failing since Nov 15, 2025 (daily tests show 2 consistent failures)
- **Fix**: Set both `DANDI_API_KEY` and `DANDI_SANDBOX_API_KEY` when uploading to sandbox, maintaining backward compatibility with older dandi versions

## Test plan
- [ ] E2E tests should now pass the "Upload pipeline output to DANDI" and "Review upload results" tests
- [ ] Verify DANDI upload still works for non-sandbox (production) uploads

🤖 Generated with [Claude Code](https://claude.com/claude-code)