### PR TITLE
Support NeuroConv 0.6.3

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,8 +15,8 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.6.2
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.2
+      - neuroconv[dandi,compressors] == 0.6.3
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.3
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -23,8 +23,8 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
-      - neuroconv[dandi,compressors] == 0.6.2
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.2
+      - neuroconv[dandi,compressors] == 0.6.3
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.3
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,8 +18,8 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.6.2
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.2
+      - neuroconv[dandi,compressors] == 0.6.3
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.3
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,8 +18,8 @@ dependencies:
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.6.2
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.2
+      - neuroconv[dandi,compressors] == 0.6.3
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.3
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1370,6 +1370,7 @@ def upload_folder_to_dandi(
     os.environ["DANDI_API_KEY"] = api_key
     if sandbox:
         os.environ["DANDI_SANDBOX_API_KEY"] = api_key
+        os.environ["DANDI_STAGING_API_KEY"] = api_key
 
     if ignore_cache:
         os.environ["DANDI_CACHE"] = "ignore"
@@ -1403,6 +1404,7 @@ def upload_project_to_dandi(
     os.environ["DANDI_API_KEY"] = api_key
     if sandbox:
         os.environ["DANDI_SANDBOX_API_KEY"] = api_key
+        os.environ["DANDI_STAGING_API_KEY"] = api_key
 
     if ignore_cache:
         os.environ["DANDI_CACHE"] = "ignore"


### PR DESCRIPTION
Pin neuroconv to 0.6.3 in all environment files.

v0.6.3 is identical to v0.6.2 (re-release for automated upload testing per [release notes](https://github.com/catalystneuro/neuroconv/releases/tag/v0.6.3)). No code changes needed beyond the version bump.

Built on top of #1034 (support-neuroconv-0.6.2).