### PR TITLE
Support NeuroConv 0.6.6

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,8 +15,8 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.6.5
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.5
+      - neuroconv[dandi,compressors] == 0.6.6
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -23,8 +23,8 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
-      - neuroconv[dandi,compressors] == 0.6.5
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.5
+      - neuroconv[dandi,compressors] == 0.6.6
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,8 +18,8 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.6.5
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.5
+      - neuroconv[dandi,compressors] == 0.6.6
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,8 +18,8 @@ dependencies:
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.6.5
-      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.5
+      - neuroconv[dandi,compressors] == 0.6.6
+      - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -205,7 +205,7 @@ def replace_none_with_nan(json_object: dict, json_schema: dict) -> dict:
 
 def autocomplete_format_string(info: dict) -> str:
     from neuroconv.tools.path_expansion import construct_path_template
-    from neuroconv.utils.json_schema import _NWBMetaDataEncoder as NWBMetaDataEncoder
+    from neuroconv.utils.json_schema import NWBMetaDataEncoder
 
     base_directory = info["base_directory"]
     filesystem_entry_path = info["path"]
@@ -240,7 +240,7 @@ def autocomplete_format_string(info: dict) -> str:
 def locate_data(info: dict) -> dict:
     """Locate data from the specifies directories using fstrings."""
     from neuroconv.tools import LocalPathExpander
-    from neuroconv.utils.json_schema import _NWBMetaDataEncoder as NWBMetaDataEncoder
+    from neuroconv.utils.json_schema import NWBMetaDataEncoder
 
     expander = LocalPathExpander()
 
@@ -431,7 +431,7 @@ def map_interfaces(callback, converter, to_match: Union["BaseDataInterface", Non
 
 def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[str, dict]:
     """Function used to fetch the metadata schema from a CustomNWBConverter instantiated from the source_data."""
-    from neuroconv.utils.json_schema import _NWBMetaDataEncoder as NWBMetaDataEncoder
+    from neuroconv.utils.json_schema import NWBMetaDataEncoder
 
     resolved_source_data = replace_none_with_nan(
         source_data, resolve_references(get_custom_converter(interfaces).get_source_schema())
@@ -1861,7 +1861,7 @@ def get_unit_table_json(interface) -> List[Dict[str, Any]]:
     A convenience function for collecting and organizing the property values of the underlying sorting extractor.
     """
 
-    from neuroconv.utils.json_schema import _NWBMetaDataEncoder as NWBMetaDataEncoder
+    from neuroconv.utils.json_schema import NWBMetaDataEncoder
 
     sorting = interface.sorting_extractor
 
@@ -1962,7 +1962,7 @@ def get_electrode_table_json(interface) -> List[Dict[str, Any]]:
     A convenience function for collecting and organizing the property values of the underlying recording extractor.
     """
 
-    from neuroconv.utils.json_schema import _NWBMetaDataEncoder as NWBMetaDataEncoder
+    from neuroconv.utils.json_schema import NWBMetaDataEncoder
 
     recording = interface.recording_extractor
 


### PR DESCRIPTION
## Changes
- Pin `neuroconv == 0.6.6` in all 4 environment files
- Revert `_NWBMetaDataEncoder` imports back to public `NWBMetaDataEncoder` (re-exported in v0.6.6 per [PR #1142](https://github.com/catalystneuro/neuroconv/pull/1142))

## NeuroConv 0.6.6 Highlights
- **`NWBMetaDataEncoder` made public again** — no longer need private `_NWBMetaDataEncoder` workaround
- Removed use of deprecated `jsonschema.RefResolver`
- Compression settings cleanup
- Various bug fixes for SpikeGLX, DeepLabCut, and ecephys interfaces

Full changelog: https://github.com/catalystneuro/neuroconv/releases/tag/v0.6.6

Chain: ...→ #1035 → #1036 → this PR