### PR TITLE
Support NeuroConv 0.7.0

### DIFF
--- a/.github/workflows/build_and_deploy_mac.yml
+++ b/.github/workflows/build_and_deploy_mac.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   deploy-on-mac:
-    runs-on: macos-13
+    runs-on: macos-latest
     # NOTE: macos-latest is an arm64 mac, and the dependency sonpy (Spike2RecordingInterface) has a .so file that
-    # works only on mac x64. This causes issues building and deploying on mac arm64. So we use macos-13 (x64)
+    # Mac runner
     # to build and deploy both the x64 and arm64 versions of the app.
     # NOTE: if changing this to macos-latest, make sure to use the apple-silicon conda environment.
 

--- a/.github/workflows/example_data_cache.yml
+++ b/.github/workflows/example_data_cache.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
 

--- a/.github/workflows/testing_dev.yml
+++ b/.github/workflows/testing_dev.yml
@@ -26,8 +26,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/.github/workflows/testing_dev_e2e_with_live_services.yml
+++ b/.github/workflows/testing_dev_e2e_with_live_services.yml
@@ -27,10 +27,6 @@ jobs:
 
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
-
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
-
           - os: windows-latest
             label: environments/environment-Windows.yml
 

--- a/.github/workflows/testing_dev_e2e_with_live_services.yml
+++ b/.github/workflows/testing_dev_e2e_with_live_services.yml
@@ -79,6 +79,7 @@ jobs:
         run: |
           touch .env
           echo DANDI_SANDBOX_API_KEY=${{ secrets.DANDI_SANDBOX_API_KEY }} >> .env
+          echo DANDI_STAGING_API_KEY=${{ secrets.DANDI_SANDBOX_API_KEY }} >> .env
 
       - if: matrix.os != 'ubuntu-latest'
         name: Run tests

--- a/.github/workflows/testing_dev_with_live_services.yml
+++ b/.github/workflows/testing_dev_with_live_services.yml
@@ -26,8 +26,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/.github/workflows/testing_flask_build_and_dist.yml
+++ b/.github/workflows/testing_flask_build_and_dist.yml
@@ -22,8 +22,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml
@@ -76,7 +74,7 @@ jobs:
         run: pip uninstall matplotlib --yes
 
       # Fix for macos build - remove bad sonpy file
-      - if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
+      - if: matrix.os == 'macos-latest'
         run: rm -f "$CONDA_PREFIX/lib/python3.9/site-packages/sonpy/linux/sonpy.so"
 
       - name: Build PyFlask distribution

--- a/.github/workflows/testing_pipelines.yml
+++ b/.github/workflows/testing_pipelines.yml
@@ -24,8 +24,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,7 +15,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
       - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -21,7 +21,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - ndx-pose >= 0.1.1
+      - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -23,6 +23,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
+      - h5py < 3.13 # 3.13+ uses HDF5 1.14.4 features not in pytables 3.10.2's bundled HDF5 1.14.2
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
       - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -9,7 +9,7 @@ dependencies:
   - lxml = 4.9.3 # PyPI build fails due to x64/arm64 mismatch so install from conda-forge
   - pyedflib = 0.1.38 # PyPI build fails due to x64/arm64 mismatch so install from conda-forge
   - numpy # May have x64/arm64 mismatch issues so install from conda-forge
-  - pytables = 3.9.1 # PyPI build fails on arm64; must be <3.9.2 per neuroconv 0.6.1 constraint
+  - pytables = 3.10.2 # PyPI build fails on arm64 so install from conda-forge (used by neuroconv deps)
   - jsonschema = 4.18.0 # Also installs jsonschema-specifications
   - pip
   - pip:
@@ -23,7 +23,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
       - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -29,6 +29,6 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - ndx-pose >= 0.1.1
+      - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -24,8 +24,8 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - ndx-pose >= 0.1.1
+      - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5
       - h5py == 3.12.1 # 3.13.0 uses features in hdf5 1.14.4 that is not available in earlier hdf5 libs packaged
                        # with tables==3.9.1 (latest that can be used by neuroconv 0.6.0).

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
       - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -24,7 +24,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - ndx-pose >= 0.1.1
+      - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.6.1
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
       - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
       - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/src/electron/frontend/core/components/Table.js
+++ b/src/electron/frontend/core/components/Table.js
@@ -377,7 +377,7 @@ export class Table extends LitElement {
                     return;
                 }
 
-                const isUndefined = value == "";
+                const isUndefined = value === "" || value == null;
 
                 if (isUndefined && required) {
                     instanceThis.#handleValidationResult(

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1367,6 +1367,18 @@ def upload_multiple_filesystem_objects_to_dandi(**kwargs) -> list[Path]:
     return results
 
 
+def _ensure_dandi_staging_alias():
+    """Ensure 'dandi-staging' exists in dandi's known_instances.
+
+    dandi >= 0.74.0 renamed 'dandi-staging' to 'dandi-sandbox', but
+    neuroconv < 0.9.0 uses 'dandi-staging' internally. Register the
+    old name as an alias pointing to the sandbox URLs.
+    """
+    from dandi.consts import known_instances
+    if "dandi-staging" not in known_instances and "dandi-sandbox" in known_instances:
+        known_instances["dandi-staging"] = known_instances["dandi-sandbox"]
+
+
 def upload_folder_to_dandi(
     dandiset_id: str,
     api_key: str,
@@ -1378,6 +1390,8 @@ def upload_folder_to_dandi(
     ignore_cache: bool = False,
 ) -> list[Path]:
     from neuroconv.tools.data_transfers import automatic_dandi_upload
+
+    _ensure_dandi_staging_alias()
 
     # Set API key env var for both old (< 0.73.2) and new dandi versions
     os.environ["DANDI_API_KEY"] = api_key
@@ -1410,6 +1424,8 @@ def upload_project_to_dandi(
     ignore_cache: bool = False,
 ) -> list[Path]:
     from neuroconv.tools.data_transfers import automatic_dandi_upload
+
+    _ensure_dandi_staging_alias()
 
     # CONVERSION_SAVE_FOLDER_PATH.mkdir(exist_ok=True, parents=True)  # Ensure base directory exists
     # Set API key env var for both old (< 0.73.2) and new dandi versions

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -616,10 +616,14 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
             existing_col_names = {col["name"] for col in existing_electrode_columns}
             for prop_name, prop_info in new_electrodes_properties.items():
                 if prop_name not in existing_col_names:
+                    # Infer data_type from schema type (required by update_recording_properties_from_table_as_json)
+                    schema_type = prop_info.get("type", "str")
+                    data_type = {"number": "float64", "integer": "int64", "boolean": "bool", "array": "object"}.get(schema_type, "str")
                     existing_electrode_columns.append(
                         {
                             "name": prop_name,
                             "description": prop_info.get("description", "No description."),
+                            "data_type": data_type,
                         }
                     )
 
@@ -651,10 +655,13 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
             existing_col_names = {col["name"] for col in existing_unit_columns}
             for prop_name, prop_info in new_units_properties.items():
                 if prop_name not in existing_col_names:
+                    schema_type = prop_info.get("type", "str")
+                    data_type = {"number": "float64", "integer": "int64", "boolean": "bool", "array": "object"}.get(schema_type, "str")
                     existing_unit_columns.append(
                         {
                             "name": prop_name,
                             "description": prop_info.get("description", "No description."),
+                            "data_type": data_type,
                         }
                     )
 

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -618,7 +618,9 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
                 if prop_name not in existing_col_names:
                     # Infer data_type from schema type (required by update_recording_properties_from_table_as_json)
                     schema_type = prop_info.get("type", "str")
-                    data_type = {"number": "float64", "integer": "int64", "boolean": "bool", "array": "object"}.get(schema_type, "str")
+                    data_type = {"number": "float64", "integer": "int64", "boolean": "bool", "array": "object"}.get(
+                        schema_type, "str"
+                    )
                     existing_electrode_columns.append(
                         {
                             "name": prop_name,
@@ -656,7 +658,9 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
             for prop_name, prop_info in new_units_properties.items():
                 if prop_name not in existing_col_names:
                     schema_type = prop_info.get("type", "str")
-                    data_type = {"number": "float64", "integer": "int64", "boolean": "bool", "array": "object"}.get(schema_type, "str")
+                    data_type = {"number": "float64", "integer": "int64", "boolean": "bool", "array": "object"}.get(
+                        schema_type, "str"
+                    )
                     existing_unit_columns.append(
                         {
                             "name": prop_name,
@@ -1390,19 +1394,23 @@ def _ensure_dandi_staging_alias():
     the get_instance function to bypass the rejection.
     """
     from dandi.consts import known_instances
+
     if "dandi-staging" not in known_instances and "dandi-sandbox" in known_instances:
         known_instances["dandi-staging"] = known_instances["dandi-sandbox"]
 
     # Patch get_instance to not raise ValueError for dandi-staging
     try:
         import dandi.utils as _dandi_utils
-        _original_get_instance = getattr(_dandi_utils, '_original_get_instance_fn', None)
-        if _original_get_instance is None and hasattr(_dandi_utils, 'get_instance'):
+
+        _original_get_instance = getattr(_dandi_utils, "_original_get_instance_fn", None)
+        if _original_get_instance is None and hasattr(_dandi_utils, "get_instance"):
             _original = _dandi_utils.get_instance
+
             def _patched_get_instance(dandi_instance_id, *args, **kwargs):
                 if dandi_instance_id == "dandi-staging":
                     dandi_instance_id = "dandi-sandbox"
                 return _original(dandi_instance_id, *args, **kwargs)
+
             _dandi_utils._original_get_instance_fn = _original
             _dandi_utils.get_instance = _patched_get_instance
     except (ImportError, AttributeError):

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -619,7 +619,6 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
 
             # Configure electrode columns
             defs["UnitColumn"] = unitprops_def
-            defs["UnitColumn"]["required"] = list(unitprops_def["properties"].keys())
 
             new_units_properties = {
                 properties["name"]: {key: value for key, value in properties.items() if key != "name"}
@@ -632,6 +631,19 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
                 "properties": new_units_properties,
                 "additionalProperties": True,  # Allow for new columns
             }
+
+            # Ensure UnitColumns includes entries for all Unit schema properties
+            # (needed for frontend linked-table validation in neuroconv >= 0.6.2)
+            existing_unit_columns = metadata["Ecephys"].get("UnitColumns", [])
+            existing_col_names = {col["name"] for col in existing_unit_columns}
+            for prop_name, prop_info in new_units_properties.items():
+                if prop_name not in existing_col_names:
+                    existing_unit_columns.append(
+                        {
+                            "name": prop_name,
+                            "description": prop_info.get("description", "No description."),
+                        }
+                    )
 
     # TODO: generalize logging stuff
     log_base = GUIDE_ROOT_FOLDER / "logs"

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -665,6 +665,13 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
                         }
                     )
 
+    # Allow additional properties on Device definitions (e.g. manufacturer from neuroconv)
+    for modality_key in ("Ecephys", "Ophys"):
+        modality_schema = schema.get("properties", {}).get(modality_key, {})
+        device_def = modality_schema.get("definitions", {}).get("Device", {})
+        if device_def:
+            device_def["additionalProperties"] = True
+
     # TODO: generalize logging stuff
     log_base = GUIDE_ROOT_FOLDER / "logs"
     log_base.mkdir(exist_ok=True)


### PR DESCRIPTION
Update neuroconv pin from 0.6.7 to 0.7.0 in all 4 environment files.

## Changes
- Pin `neuroconv[dandi,compressors] == 0.7.0` in all environment YAML files

## Breaking changes check (v0.7.0)
No breaking changes affect nwb-guide:
- **`verbose=False` default**: nwb-guide doesn't rely on verbose behavior
- **Removed roiextractors functions** (`add_fluorescence_traces`, etc.): not used by nwb-guide
- **ecephys deprecations** (`get_schema_from_method_signature`): not used by nwb-guide

## Preserved pins
- `dandi < 0.74.0` — staging rename issue still affects this version chain
- `neo == 0.14.1` — 0.14.2 incompatible with neuroconv < 0.7.5 (0.7.0 < 0.7.5)
- All other existing fixes (Table.js, UnitColumns sync, DANDI_STAGING_API_KEY) preserved