### PR TITLE
Support NeuroConv 0.7.4

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -24,6 +24,6 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,7 +15,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.7.3
+      - neuroconv[dandi,compressors] == 0.7.4
       - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -23,7 +23,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -32,5 +32,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -23,7 +23,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
-      - neuroconv[dandi,compressors] == 0.7.3
+      - neuroconv[dandi,compressors] == 0.7.4
       - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -31,6 +31,6 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.7.3
+      - neuroconv[dandi,compressors] == 0.7.4
       - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -26,7 +26,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5
       - h5py == 3.12.1 # 3.13.0 uses features in hdf5 1.14.4 that is not available in earlier hdf5 libs packaged

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -27,7 +27,7 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5
       - h5py == 3.12.1 # 3.13.0 uses features in hdf5 1.14.4 that is not available in earlier hdf5 libs packaged
                        # with tables==3.9.1 (latest that can be used by neuroconv 0.6.0).

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -27,6 +27,6 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.7.3
+      - neuroconv[dandi,compressors] == 0.7.4
       - dandi < 0.74.0  # 0.74.0 renamed dandi-staging to dandi-sandbox, breaking neuroconv 0.6.6
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -26,7 +26,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5


### PR DESCRIPTION
Bump neuroconv from 0.7.3 to 0.7.4 in all environment files.