### PR TITLE
Support NeuroConv 0.8.0

### DIFF
--- a/.github/workflows/build_and_deploy_mac.yml
+++ b/.github/workflows/build_and_deploy_mac.yml
@@ -7,9 +7,9 @@ on:
 
 jobs:
   deploy-on-mac:
-    runs-on: macos-13
+    runs-on: macos-latest
     # NOTE: macos-latest is an arm64 mac, and the dependency sonpy (Spike2RecordingInterface) has a .so file that
-    # works only on mac x64. This causes issues building and deploying on mac arm64. So we use macos-13 (x64)
+    # Mac runner
     # to build and deploy both the x64 and arm64 versions of the app.
     # NOTE: if changing this to macos-latest, make sure to use the apple-silicon conda environment.
 

--- a/.github/workflows/example_data_cache.yml
+++ b/.github/workflows/example_data_cache.yml
@@ -21,7 +21,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ["3.12"]
-        os: [ubuntu-latest, windows-latest, macos-latest, macos-13]
+        os: [ubuntu-latest, windows-latest, macos-latest]
 
     steps:
 

--- a/.github/workflows/testing_dev.yml
+++ b/.github/workflows/testing_dev.yml
@@ -26,8 +26,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/.github/workflows/testing_dev_e2e_with_live_services.yml
+++ b/.github/workflows/testing_dev_e2e_with_live_services.yml
@@ -27,10 +27,6 @@ jobs:
 
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
-
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
-
           - os: windows-latest
             label: environments/environment-Windows.yml
 

--- a/.github/workflows/testing_dev_with_live_services.yml
+++ b/.github/workflows/testing_dev_with_live_services.yml
@@ -26,8 +26,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/.github/workflows/testing_flask_build_and_dist.yml
+++ b/.github/workflows/testing_flask_build_and_dist.yml
@@ -22,8 +22,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml
@@ -76,7 +74,7 @@ jobs:
         run: pip uninstall matplotlib --yes
 
       # Fix for macos build - remove bad sonpy file
-      - if: matrix.os == 'macos-latest' || matrix.os == 'macos-13'
+      - if: matrix.os == 'macos-latest'
         run: rm -f "$CONDA_PREFIX/lib/python3.9/site-packages/sonpy/linux/sonpy.so"
 
       - name: Build PyFlask distribution

--- a/.github/workflows/testing_pipelines.yml
+++ b/.github/workflows/testing_pipelines.yml
@@ -24,8 +24,6 @@ jobs:
           - os: macos-latest  # Mac arm64 runner
             label: environments/environment-MAC-apple-silicon.yml
 
-          - os: macos-13  # Mac x64 runner
-            label: environments/environment-MAC-intel.yml
 
           - os: windows-latest
             label: environments/environment-Windows.yml

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,9 +15,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
-      - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
-      - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.8.0
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -24,9 +24,7 @@ dependencies:
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
       - h5py < 3.13 # 3.13+ uses HDF5 1.14.4 features not in pytables 3.10.2's bundled HDF5 1.14.2
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
-      - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
-      - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.8.0
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,9 +18,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
-      - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
-      - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.8.0
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,9 +18,7 @@ dependencies:
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.7.0
-      - pandas < 3.0  # pandas 3.0 returns read-only arrays, breaking spikeinterface Phy extractor
-      - neo == 0.14.1 # 0.14.2 is not compatible with neuroconv < 0.7.5
+      - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.8.0
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling


### PR DESCRIPTION
Update neuroconv from 0.7.0 to 0.8.0. No breaking changes affecting nwb-guide imports or API usage.