### PR TITLE
Support NeuroConv 0.9.1

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -22,6 +22,6 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -15,7 +15,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.9.0
+      - neuroconv[dandi,compressors] == 0.9.1
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -21,7 +21,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -30,5 +30,5 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -29,6 +29,6 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -23,7 +23,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       # NOTE: the NeuroConv wheel on PyPI includes sonpy which is not compatible with arm64, so build and install
       # NeuroConv from GitHub, which will remove the sonpy dependency when building from Mac arm64
-      - neuroconv[dandi,compressors] == 0.9.0
+      - neuroconv[dandi,compressors] == 0.9.1
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -24,7 +24,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5
       - h5py == 3.12.1 # 3.13.0 uses features in hdf5 1.14.4 that is not available in earlier hdf5 libs packaged

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -25,7 +25,7 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5
       - h5py == 3.12.1 # 3.13.0 uses features in hdf5 1.14.4 that is not available in earlier hdf5 libs packaged
                        # with tables==3.9.1 (latest that can be used by neuroconv 0.6.0).

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask-cors == 4.0.0
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.9.0
+      - neuroconv[dandi,compressors] == 0.9.1
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -25,6 +25,6 @@ dependencies:
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
       - ndx-pose == 0.1.1
-      - nwbinspector == 0.6.2
+      - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask-cors === 3.0.10
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
-      - neuroconv[dandi,compressors] == 0.9.0
+      - neuroconv[dandi,compressors] == 0.9.1
       - spikeinterface >= 0.101.0 # Previously included via neuroconv[ecephys]; needed for tutorial data generation
       - pandas < 3.0 # pandas 3.0 uses Arrow backend by default, returning read-only arrays that break spikeinterface Phy extractor
       - scikit-learn == 1.4.0 # Tutorial data generation

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -24,7 +24,7 @@ dependencies:
       - scikit-learn == 1.4.0 # Tutorial data generation
       - tqdm_publisher >= 0.0.1 # Progress bars
       - tzlocal >= 5.2 # Frontend timezone handling
-      - ndx-pose == 0.1.1
+      - ndx-pose >= 0.1.1
       - nwbinspector >= 0.6.2
       - tables
       - numcodecs < 0.16.0  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -610,6 +610,19 @@ def get_metadata_schema(source_data: Dict[str, dict], interfaces: dict) -> Dict[
             "additionalProperties": True,  # Allow for new columns
         }
 
+        # Ensure ElectrodeColumns includes entries for all Electrode schema properties
+        # (needed for frontend linked-table validation in neuroconv >= 0.7.5)
+        existing_electrode_columns = ecephys_metadata.get("ElectrodeColumns", [])
+        existing_ecol_names = {col["name"] for col in existing_electrode_columns}
+        for prop_name, prop_info in new_electrodes_properties.items():
+            if prop_name not in existing_ecol_names:
+                existing_electrode_columns.append(
+                    {
+                        "name": prop_name,
+                        "description": prop_info.get("description", "No description."),
+                    }
+                )
+
         if has_units:
 
             unitprops_def = defs["UnitProperties"]


### PR DESCRIPTION
## Changes
- Update neuroconv to 0.9.1 in all 4 environment files

## Notable neuroconv 0.9.1 changes
- Bug fixes for `add_electrodes_to_nwbfile` and `add_sorting_to_nwbfile` null value handling
- Updated DANDI instance names for Ember upload
- No breaking changes affecting nwb-guide