### PR TITLE
Add 7 previously excluded neuroconv interfaces to NWB GUIDE

### DIFF
--- a/src/pyflask/tests/test_new_interfaces.py
+++ b/src/pyflask/tests/test_new_interfaces.py
@@ -1,8 +1,9 @@
 """Tests for newly added interfaces that were previously excluded from selection."""
 
-import pytest
-import sys
 import os
+import sys
+
+import pytest
 
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
@@ -50,15 +51,15 @@ class TestNewInterfacesIncluded:
 
     @pytest.mark.parametrize("interface_name", NEW_INTERFACE_NAMES)
     def test_interface_present(self, interface_names, interface_name):
-        assert interface_name in interface_names, (
-            f"{interface_name} should be present in get_all_interface_info() but was not found"
-        )
+        assert (
+            interface_name in interface_names
+        ), f"{interface_name} should be present in get_all_interface_info() but was not found"
 
     @pytest.mark.parametrize("interface_name", SHOULD_REMAIN_EXCLUDED)
     def test_interface_still_excluded(self, interface_names, interface_name):
-        assert interface_name not in interface_names, (
-            f"{interface_name} should remain excluded but was found in get_all_interface_info()"
-        )
+        assert (
+            interface_name not in interface_names
+        ), f"{interface_name} should remain excluded but was found in get_all_interface_info()"
 
 
 class TestNewInterfaceSchemas:

--- a/src/pyflask/tests/test_new_interfaces.py
+++ b/src/pyflask/tests/test_new_interfaces.py
@@ -1,0 +1,73 @@
+"""Tests for newly added interfaces that were previously excluded from selection."""
+
+import pytest
+import sys
+import os
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+NEW_INTERFACE_NAMES = [
+    "CsvTimeIntervalsInterface",
+    "ExcelTimeIntervalsInterface",
+    "Hdf5ImagingInterface",
+    "MaxOneRecordingInterface",
+    "OpenEphysSortingInterface",
+    "AxonaPositionDataInterface",
+    "AxonaUnitRecordingInterface",
+]
+
+SHOULD_REMAIN_EXCLUDED = [
+    "SpikeGLXLFPInterface",
+    "CEDRecordingInterface",
+    "OpenEphysBinaryRecordingInterface",
+    "OpenEphysLegacyRecordingInterface",
+    "SimaSegmentationInterface",
+]
+
+
+def get_interface_info():
+    from manageNeuroconv.manage_neuroconv import get_all_interface_info
+
+    return get_all_interface_info()
+
+
+def get_all_interface_class_names(info: dict) -> list:
+    """Extract all interface class names from the info dict."""
+    return [v["name"] for v in info.values()]
+
+
+class TestNewInterfacesIncluded:
+    """Verify that newly un-excluded interfaces appear in get_all_interface_info()."""
+
+    @pytest.fixture(scope="class")
+    def interface_info(self):
+        return get_interface_info()
+
+    @pytest.fixture(scope="class")
+    def interface_names(self, interface_info):
+        return get_all_interface_class_names(interface_info)
+
+    @pytest.mark.parametrize("interface_name", NEW_INTERFACE_NAMES)
+    def test_interface_present(self, interface_names, interface_name):
+        assert interface_name in interface_names, (
+            f"{interface_name} should be present in get_all_interface_info() but was not found"
+        )
+
+    @pytest.mark.parametrize("interface_name", SHOULD_REMAIN_EXCLUDED)
+    def test_interface_still_excluded(self, interface_names, interface_name):
+        assert interface_name not in interface_names, (
+            f"{interface_name} should remain excluded but was found in get_all_interface_info()"
+        )
+
+
+class TestNewInterfaceSchemas:
+    """Verify that source schemas can be retrieved for each new interface."""
+
+    @pytest.mark.parametrize("interface_name", NEW_INTERFACE_NAMES)
+    def test_source_schema(self, interface_name):
+        from manageNeuroconv.manage_neuroconv import get_source_schema
+
+        schema = get_source_schema({interface_name: interface_name})
+        assert isinstance(schema, dict)
+        assert "properties" in schema or "additionalProperties" in schema or "type" in schema


### PR DESCRIPTION
## Summary

Removes 7 interfaces from the `exclude_interfaces_from_selection` list in `get_all_interface_info()`, making them available in the NWB GUIDE interface selection UI. These interfaces exist in neuroconv 0.9.1 and were previously excluded.

### Newly available interfaces:
- **CsvTimeIntervalsInterface** — CSV time intervals (trials, epochs, etc.)
- **ExcelTimeIntervalsInterface** — Excel time intervals
- **Hdf5ImagingInterface** — HDF5-based imaging data
- **MaxOneRecordingInterface** — MaxOne/Maxwell recording data
- **OpenEphysSortingInterface** — OpenEphys spike sorting data
- **AxonaPositionDataInterface** — Axona position tracking
- **AxonaUnitRecordingInterface** — Axona unit recordings

### Still excluded (with reason):
- `SpikeGLXLFPInterface` (deprecated)
- `CEDRecordingInterface`, `OpenEphysBinaryRecordingInterface`, `OpenEphysLegacyRecordingInterface` (aliases)
- `SimaSegmentationInterface` (unmaintained SIMA dependency)

### Notes
- `ExternalVideoInterface` and `ScanImageImagingInterface` are already included (not in the exclude list) but have display name collisions with `InternalVideoInterface` and `ScanImageLegacyImagingInterface` respectively — this is a neuroconv upstream issue.
- Added `test_new_interfaces.py` with 19 tests verifying inclusion/exclusion and source schema retrieval.

### Testing
- All Python tests pass (`pytest src/pyflask/tests/test_neuroconv.py src/pyflask/tests/test_new_interfaces.py` — 22 passed)