### PR TITLE
Make tutorial data generation faster

### DIFF
--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1812,7 +1812,7 @@ def generate_test_data(output_path: str):
     sorting_analyzer = spikeinterface.create_sorting_analyzer(
         sorting=sorting, recording=artificial_ap_band_in_uV, mode="memory", sparse=False
     )
-    sorting_analyzer.compute(["random_spikes"])
+    sorting_analyzer.compute(["random_spikes", "waveforms", "templates"])
 
     spikeinterface.exporters.export_to_phy(
         sorting_analyzer=sorting_analyzer,

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1812,12 +1812,15 @@ def generate_test_data(output_path: str):
     sorting_analyzer = spikeinterface.create_sorting_analyzer(
         sorting=sorting, recording=artificial_ap_band_in_uV, mode="memory", sparse=False
     )
-    sorting_analyzer.compute(["random_spikes", "waveforms", "templates", "noise_levels"])
-    sorting_analyzer.compute("spike_amplitudes")
-    sorting_analyzer.compute("principal_components", n_components=5, mode="by_channel_local")
+    sorting_analyzer.compute(["random_spikes"])
 
     spikeinterface.exporters.export_to_phy(
-        sorting_analyzer=sorting_analyzer, output_folder=phy_output_folder, remove_if_exists=True, copy_binary=False
+        sorting_analyzer=sorting_analyzer,
+        output_folder=phy_output_folder,
+        remove_if_exists=True,
+        copy_binary=False,
+        compute_pc_features=False,
+        compute_amplitudes=False,
     )
 
 


### PR DESCRIPTION
While the caching of tutorial data in CI is not a terrible idea overall, it is a workaround to a broader issue

Prior to when I began the work on https://github.com/NeurodataWithoutBorders/nwb-guide/pull/917 ( to support modern versions of SpikeInterface for the tutorial generation), the tutorial data generation step usually took less than 30 seconds to complete, if not faster (this can be tested using the previous releases)

I was unable to finish the debugging on that PR before work stopped on the project. When others finished the work and merged, they introduced an immense slowdown by adding the lines that this PR removes involving PC estimation

This means all releases after v1.0.5 suffered from this slowdown for any users attempting to follow the tutorials from the docs