### PR TITLE
Pin numpy < 2 to fix PyInstaller bundling

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -22,4 +22,5 @@ dependencies:
       - ndx-pose == 0.2.2
       - nwbinspector == 0.6.5
       - tables
+      - numpy < 2  # numpy 2.x breaks PyInstaller 6.7.0 bundling (missing numpy._core._exceptions)
       - numcodecs == 0.15.1  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -30,4 +30,5 @@ dependencies:
       - tzlocal == 5.3.1 # Frontend timezone handling
       - ndx-pose == 0.2.2
       - nwbinspector == 0.6.5
+      - numpy < 2  # numpy 2.x breaks PyInstaller 6.7.0 bundling (pin in pip too, since pip can override conda)
       - numcodecs == 0.15.1  # numcodecs 0.16.0 is not compatible with zarr 2.18.5

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -8,7 +8,7 @@ dependencies:
   # Install these from conda-forge so that dependent packages get included in the distributable
   - lxml = 4.9.3 # PyPI build fails due to x64/arm64 mismatch so install from conda-forge
   - pyedflib = 0.1.38 # PyPI build fails due to x64/arm64 mismatch so install from conda-forge
-  - numpy # May have x64/arm64 mismatch issues so install from conda-forge
+  - numpy < 2 # May have x64/arm64 mismatch issues so install from conda-forge; < 2 for PyInstaller compat
   - pytables = 3.10.2 # PyPI build fails on arm64 so install from conda-forge (used by neuroconv deps)
   - jsonschema = 4.18.0 # Also installs jsonschema-specifications
   - pip

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -23,6 +23,7 @@ dependencies:
       - tzlocal == 5.3.1 # Frontend timezone handling
       - ndx-pose == 0.2.2
       - nwbinspector == 0.6.5
+      - numpy < 2  # numpy 2.x breaks PyInstaller 6.7.0 bundling (missing numpy._core._exceptions)
       - numcodecs == 0.15.1  # numcodecs 0.16.0 is not compatible with zarr 2.18.5
       - h5py == 3.12.1 # 3.13.0 uses features in hdf5 1.14.4 that is not available in earlier hdf5 libs packaged
                        # with tables==3.9.1 (latest that can be used by neuroconv 0.6.0).

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -25,4 +25,5 @@ dependencies:
       - ndx-pose == 0.2.2
       - nwbinspector == 0.6.5
       - tables
+      - numpy < 2  # numpy 2.x breaks PyInstaller 6.7.0 bundling (missing numpy._core._exceptions)
       - numcodecs == 0.15.1  # numcodecs 0.16.0 is not compatible with zarr 2.18.5


### PR DESCRIPTION
## Summary
- Pin `numpy < 2` in all 4 environment files
- numpy 2.x reorganized internals from `numpy.core` to `numpy._core`, but PyInstaller 6.7.0 + pyinstaller-hooks-contrib 2024.6 doesn't bundle `numpy._core._exceptions`, causing `ModuleNotFoundError` at runtime in the built executable
- This is a stopgap — a follow-up PR will upgrade PyInstaller to support numpy 2.x properly

## Test plan
- [ ] BuildTests pass on all platforms (windows-latest, macos-latest, macos-15-intel)

🤖 Generated with [Claude Code](https://claude.com/claude-code)