### PR TITLE
Fix species metadata crash on bundled app

### DIFF
--- a/nwb-guide.spec
+++ b/nwb-guide.spec
@@ -25,6 +25,7 @@ datas += collect_data_files('jsonschema_specifications')
 # Various consequences of lazy imports
 modules_to_collect = [
     'dandi',
+    'dandischema',
     'keyrings',
     'unittest',
     'nwbinspector',

--- a/src/electron/frontend/core/server/globals.ts
+++ b/src/electron/frontend/core/server/globals.ts
@@ -45,7 +45,10 @@ export const serverGlobals = {
     species: new Promise((res, rej) => {
       onServerOpen(() => {
         fetch(new URL("/dandi/get-recommended-species", baseUrl))
-          .then((res) => res.json())
+          .then((res) => {
+            if (!res.ok) throw new Error(`Failed to fetch species: ${res.status}`);
+            return res.json();
+          })
           .then((species) => {
             res(species)
             serverGlobals.species = species
@@ -56,7 +59,10 @@ export const serverGlobals = {
     cpus: new Promise((res, rej) => {
       onServerOpen(() => {
         fetch(new URL("/system/cpus", baseUrl))
-          .then((res) => res.json())
+          .then((res) => {
+            if (!res.ok) throw new Error(`Failed to fetch CPUs: ${res.status}`);
+            return res.json();
+          })
           .then((cpus) => {
             res(cpus)
             serverGlobals.cpus = cpus


### PR DESCRIPTION
## Summary
- Add `dandischema` to `modules_to_collect` in the PyInstaller spec so its data files (e.g., `spdx_license_ids.json`) are bundled. This was causing the `/dandi/get-recommended-species` endpoint to fail with a `FileNotFoundError` in the packaged app.
- Add `res.ok` checks to fetch handlers in `globals.ts` so that HTTP 500 responses are properly rejected instead of being parsed as JSON and passed to `getSpeciesInfo`, which crashes on non-array input.

Resolves #1071

## Test plan
- [x] Build the app with PyInstaller and verify `/dandi/get-recommended-species` returns species data
- [x] Verify the File Metadata page loads without errors in the bundled app

🤖 Generated with [Claude Code](https://claude.com/claude-code)