### PR TITLE
Fix daily CI failures from spikeinterface/scipy dependency drift

### DIFF
--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -16,7 +16,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
-      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
+      - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -17,6 +17,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
+      - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -18,6 +18,7 @@ dependencies:
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
+      - pandas < 3 # pandas 3.0 makes DataFrame.values read-only (copy-on-write), which breaks spikeinterface's in-place Phy unit_id assignment
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-Linux.yml
+++ b/environments/environment-Linux.yml
@@ -16,6 +16,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
+      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -23,6 +23,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - h5py < 3.13 # 3.13+ uses HDF5 1.14.4 features not in pytables 3.10.2's bundled HDF5 1.14.2
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
+      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -23,7 +23,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - h5py < 3.13 # 3.13+ uses HDF5 1.14.4 features not in pytables 3.10.2's bundled HDF5 1.14.2
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
-      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
+      - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -24,6 +24,7 @@ dependencies:
       - h5py < 3.13 # 3.13+ uses HDF5 1.14.4 features not in pytables 3.10.2's bundled HDF5 1.14.2
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
+      - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-apple-silicon.yml
+++ b/environments/environment-MAC-apple-silicon.yml
@@ -25,6 +25,7 @@ dependencies:
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
+      - pandas < 3 # pandas 3.0 makes DataFrame.values read-only (copy-on-write), which breaks spikeinterface's in-place Phy unit_id assignment
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,6 +18,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
+      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -19,6 +19,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
+      - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
-      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
+      - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-MAC-intel.yml
+++ b/environments/environment-MAC-intel.yml
@@ -20,6 +20,7 @@ dependencies:
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
+      - pandas < 3 # pandas 3.0 makes DataFrame.values read-only (copy-on-write), which breaks spikeinterface's in-place Phy unit_id assignment
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,6 +18,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
+      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -19,6 +19,7 @@ dependencies:
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
+      - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -18,7 +18,7 @@ dependencies:
       - flask_restx == 1.1.0
       - werkzeug < 3.0 # werkzeug 3.0 deprecates features used by flask 2.3.2. Remove this when updating flask.
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
-      - spikeinterface == 0.104.8 # Pin the ecephys backend (transitive dependency of neuroconv) used by tutorial data generation
+      - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/environments/environment-Windows.yml
+++ b/environments/environment-Windows.yml
@@ -20,6 +20,7 @@ dependencies:
       - neuroconv[dandi,compressors,ecephys,ophys,behavior,text] == 0.9.3
       - spikeinterface >= 0.104.8 # ecephys backend (transitive dependency of neuroconv); 0.104.8+ supports ignore_low_freq_error used by tutorial data generation
       - scipy >= 1.18.0 # transitive dependency; nwb-guide.spec bundles scipy._external.array_api_compat.numpy.fft, which moved to that path in scipy 1.18.0
+      - pandas < 3 # pandas 3.0 makes DataFrame.values read-only (copy-on-write), which breaks spikeinterface's in-place Phy unit_id assignment
       - scikit-learn == 1.6.1 # Tutorial data generation
       - tqdm_publisher == 0.1.1 # Progress bars
       - tzlocal == 5.3.1 # Frontend timezone handling

--- a/nwb-guide.spec
+++ b/nwb-guide.spec
@@ -17,7 +17,7 @@ hiddenimports = [
     *collect_submodules('scipy.special.cython_special'),
     *collect_submodules('scipy.special._cdflib'),
     *collect_submodules('scipy._cyutility'),
-    'scipy._lib.array_api_compat.numpy.fft',
+    'scipy._external.array_api_compat.numpy.fft',
 ]
 
 datas += collect_data_files('jsonschema_specifications')

--- a/src/pyflask/manageNeuroconv/manage_neuroconv.py
+++ b/src/pyflask/manageNeuroconv/manage_neuroconv.py
@@ -1781,8 +1781,10 @@ def generate_test_data(output_path: str):
     int16_artificial_ap_band = unscaled_artificial_ap_band.astype(dtype="int16")
     int16_artificial_ap_band.set_channel_gains(conversion_factor_to_uV)
 
+    # The low freq_min is intended for this synthetic LFP band. spikeinterface guards low freq_min values with an
+    # error, and ignore_low_freq_error permits them.
     unscaled_artificial_lf_filter = spikeinterface.preprocessing.bandpass_filter(
-        recording=unscaled_artificial_ap_band, freq_min=0.5, freq_max=1_000
+        recording=unscaled_artificial_ap_band, freq_min=0.5, freq_max=1_000, ignore_low_freq_error=True
     )
     unscaled_artificial_lf_band = spikeinterface.preprocessing.decimate(
         recording=unscaled_artificial_lf_filter, decimation_factor=downsample_factor


### PR DESCRIPTION
## Problem

The **Daily Tests** workflow had been failing every day, and the `Deploy` (PR) workflow had failed on every PR since mid-March 2026. The failures trace to dependency drift in `spikeinterface`, its transitive `scipy`, and `pandas`.

## Root causes and fixes

### 1. `DevTests` / `BuildTests`: spikeinterface low `freq_min` guard

Recent `spikeinterface` added a `highpass_check` that raises `ValueError` when `bandpass_filter` receives a `freq_min` below its threshold:

```
ValueError: The freq_min (0.5 Hz) is too low ... You can set 'ignore_low_freq_error=True' to bypass this error...
```

`generate_test_data` intentionally uses `freq_min=0.5` Hz for the synthetic LFP band, so it now passes `ignore_low_freq_error=True`.

### 2. `BuildTests`: scipy `array_api_compat` moved, plus a scipy floor

`scipy` relocated `array_api_compat` from `scipy._lib` to `scipy._external` in **scipy 1.18.0**. The PyInstaller spec pinned the old path, so the built executable crashed with:

```
ModuleNotFoundError: No module named 'scipy._external.array_api_compat.numpy.fft'
```

The spec now bundles `scipy._external.array_api_compat.numpy.fft`, and the environment files floor `scipy >= 1.18.0` so the bundled path is guaranteed to exist (spikeinterface's own scipy floor is far below this).

### 3. spikeinterface version floor

`spikeinterface` was only a transitive dependency of `neuroconv` (which requires `>= 0.103.0`), so the installed version drifted. All four environment files now floor it at `>= 0.104.8`, the version providing `ignore_low_freq_error`. A floor (not an exact pin) keeps the daily tests able to catch future drift.

### 4. `E2ELiveServices`: pandas 3.0 read-only array in the Phy extractor

`POST /neuroconv/metadata` returned 500 when instantiating a `PhySortingInterface`:

```
spikeinterface/extractors/phykilosortextractors.py, in __init__
    unit_ids[i] = new_si_id
ValueError: assignment destination is read-only
```

**pandas 3.0** makes Copy-on-Write permanent, so `DataFrame.values` returns a read-only array, and spikeinterface's Phy extractor assigns into it in place. The environment files now cap `pandas < 3` until spikeinterface stops mutating the read-only array. Reported upstream: SpikeInterface/spikeinterface#4687.

## Verification

- `pytest src/pyflask/tests/` passes (previously `test_generate_test_data` failed).
- All `Deploy` CI jobs are green across ubuntu, macOS (arm64 + intel), and Windows: `DevTests`, `BuildTests`, `LiveServices`, `E2ELiveServices`, and `ExampleDataTests`.
- The pandas fix resolved the entire `E2ELiveServices` failure: the earlier frontend `TypeError`s (e.g. reading `form` on an undefined modal) were downstream of the metadata 500, not a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)