### PR TITLE
Pin prettier and stop pre-commit.ci autofixing PRs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,3 +1,7 @@
+ci:
+  # Report formatting issues as check failures instead of pushing auto-fix commits onto pull requests.
+  autofix_prs: false
+
 repos:
 
 -   repo: https://github.com/pre-commit/pre-commit-hooks
@@ -23,6 +27,8 @@ repos:
     hooks:
     -   id: prettier
         types_or: [css, javascript]
+        additional_dependencies:
+        -   prettier@3.8.5 # Pin prettier for reproducible formatting
 
 - repo: https://github.com/codespell-project/codespell
   rev: v2.4.1

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,3 +1,6 @@
 tools/**/*
 **/dist/**/*
 **/build/**/*
+
+# prettier mangles CSS attribute selectors containing "//" (e.g. a[href^="http://"]) by moving the brace to its own line
+src/electron/frontend/assets/css/nativize.css


### PR DESCRIPTION
## Summary

The prettier pre-commit hook did not pin a prettier version, so `pre-commit.ci` resolved it to inconsistent prettier 4 alpha builds and pushed a spurious `[pre-commit.ci] auto fixes` commit onto every PR. This fixes the tooling:

- **Pin `prettier@3.8.5`** (newest release that parses the repo's `import ... assert { type: "json" }` syntax). It reformats the existing code with **zero changes**, so formatting is now reproducible and idempotent.
- **Exclude `nativize.css`** from prettier, which mangles it because of CSS attribute selectors containing `//` (e.g. `a[href^="http://"]`).
- **Set `ci.autofix_prs: false`** so `pre-commit.ci` reports formatting issues as a check result instead of pushing commits onto PRs.

No source files are reformatted. Verified locally: a fresh `pre-commit run --all-files` passes all hooks and is idempotent.

## Follow-up (separate PR)

Prettier 3.9+ drops `assert` support in favor of import attributes (`with`). Migrating requires upgrading Vite (its bundled esbuild 0.18 cannot parse `with`), so it is out of scope here.