### PR TITLE
Diagnose macOS Intel E2E flake (Electron quitting mid-test)

### DIFF
--- a/.github/workflows/deploy_tests_on_pull_request.yml
+++ b/.github/workflows/deploy_tests_on_pull_request.yml
@@ -9,32 +9,9 @@ concurrency:
 
 jobs:
 
-  DevTests:
-    uses: ./.github/workflows/testing_dev.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
-  LiveServices:
-    uses: ./.github/workflows/testing_dev_with_live_services.yml
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
-
+  # NOTE: diagnostic branch only. Trimmed to just the flaky E2E job to iterate quickly. Do not merge.
   E2ELiveServices:
     uses: ./.github/workflows/testing_dev_e2e_with_live_services.yml
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
       DANDI_SANDBOX_API_KEY: ${{ secrets.DANDI_SANDBOX_API_KEY }}
-
-  BuildTests:
-    uses: ./.github/workflows/testing_flask_build_and_dist.yml
-
-  ExampleDataCache:
-    uses: ./.github/workflows/example_data_cache.yml
-    secrets:
-      AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
-      AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      S3_GIN_BUCKET: ${{ secrets.S3_GIN_BUCKET }}
-
-  ExampleDataTests:
-    needs: ExampleDataCache
-    uses: ./.github/workflows/testing_pipelines.yml

--- a/.github/workflows/testing_dev_e2e_with_live_services.yml
+++ b/.github/workflows/testing_dev_e2e_with_live_services.yml
@@ -22,17 +22,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-latest
-            label: environments/environment-Linux.yml
-
-          - os: macos-latest  # Mac arm64 runner
-            label: environments/environment-MAC-apple-silicon.yml
-
+          # NOTE: diagnostic branch only. Reduced to the flaky x64 runner. Do not merge.
           - os: macos-15-intel  # Mac x64 runner
             label: environments/environment-MAC-intel.yml
-
-          - os: windows-latest
-            label: environments/environment-Windows.yml
 
     steps:
       - uses: actions/checkout@v6

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -38,19 +38,23 @@ if (runByTestSuite) {
 
 // TODO(e2e-flake): temporary diagnostics to pin why Electron quits mid-test on the macOS Intel runner. Remove once identified.
 if (runByTestSuite) {
+  // Log which signal (if any) arrives, then re-raise it so the default behavior is unchanged (no masking).
   ;['SIGINT', 'SIGTERM', 'SIGHUP'].forEach((sig) =>
-    process.on(sig as NodeJS.Signals, () => {
+    process.once(sig as NodeJS.Signals, () => {
       console.log(`[quit-diagnostic] process received ${sig}`)
-      app.quit() // preserve graceful shutdown while logging the signal
+      process.kill(process.pid, sig as NodeJS.Signals)
     })
   )
   process.on('exit', (code) => console.log(`[quit-diagnostic] main process exit, code ${code}`))
   app.on('render-process-gone', (_e, _wc, details) =>
-    console.log(`[quit-diagnostic] render-process-gone: ${JSON.stringify(details)}`)
+    console.log(`[quit-diagnostic] app render-process-gone: ${JSON.stringify(details)}`)
   )
   app.on('child-process-gone', (_e, details) =>
-    console.log(`[quit-diagnostic] child-process-gone: ${JSON.stringify(details)}`)
+    console.log(`[quit-diagnostic] app child-process-gone: ${JSON.stringify(details)}`)
   )
+  app.on('will-quit', () => console.log('[quit-diagnostic] app will-quit'))
+  app.on('quit', () => console.log('[quit-diagnostic] app quit'))
+  app.on('window-all-closed', () => console.log('[quit-diagnostic] app window-all-closed'))
 }
 
 /*************************************************************
@@ -431,7 +435,18 @@ app.on('activate', () => {
 
 const root = runByTestSuite ? path.join(paths.root, '.test') : paths.root
 
-if (runByTestSuite) onWindowReady(() => console.log('WINDOW READY FOR TESTING'))
+if (runByTestSuite) onWindowReady((win) => {
+  console.log('WINDOW READY FOR TESTING')
+  // TODO(e2e-flake): temporary window/renderer lifecycle diagnostics. Remove once identified.
+  const wc = win.webContents
+  wc.on('render-process-gone', (_e, details) => console.log(`[quit-diagnostic] webContents render-process-gone: ${JSON.stringify(details)}`))
+  wc.on('unresponsive', () => console.log('[quit-diagnostic] webContents unresponsive'))
+  wc.on('responsive', () => console.log('[quit-diagnostic] webContents responsive'))
+  wc.on('destroyed', () => console.log('[quit-diagnostic] webContents destroyed'))
+  wc.on('did-fail-load', (_e, code, desc) => console.log(`[quit-diagnostic] webContents did-fail-load: ${code} ${desc}`))
+  win.on('close', () => console.log('[quit-diagnostic] window close'))
+  win.on('closed', () => console.log('[quit-diagnostic] window closed'))
+})
 
 
 const homeDirectory = app.getPath("home");

--- a/src/electron/main/main.ts
+++ b/src/electron/main/main.ts
@@ -36,6 +36,23 @@ if (runByTestSuite) {
   if (process.env.CI) app.commandLine.appendSwitch('disable-gpu') // Avoid GPU process crashes on CI runners (e.g. macOS Intel)
 }
 
+// TODO(e2e-flake): temporary diagnostics to pin why Electron quits mid-test on the macOS Intel runner. Remove once identified.
+if (runByTestSuite) {
+  ;['SIGINT', 'SIGTERM', 'SIGHUP'].forEach((sig) =>
+    process.on(sig as NodeJS.Signals, () => {
+      console.log(`[quit-diagnostic] process received ${sig}`)
+      app.quit() // preserve graceful shutdown while logging the signal
+    })
+  )
+  process.on('exit', (code) => console.log(`[quit-diagnostic] main process exit, code ${code}`))
+  app.on('render-process-gone', (_e, _wc, details) =>
+    console.log(`[quit-diagnostic] render-process-gone: ${JSON.stringify(details)}`)
+  )
+  app.on('child-process-gone', (_e, details) =>
+    console.log(`[quit-diagnostic] child-process-gone: ${JSON.stringify(details)}`)
+  )
+}
+
 /*************************************************************
  * Python Process
  *************************************************************/
@@ -449,6 +466,8 @@ app.on("window-all-closed", () => {
 })
 
 app.on("before-quit", async (ev: Event) => {
+
+  if (runByTestSuite) console.log(`[quit-diagnostic] before-quit fired\n${new Error().stack}`) // TODO(e2e-flake): remove once identified
 
   ev.preventDefault()
     if (!runByTestSuite) {


### PR DESCRIPTION
## Purpose

Temporary **diagnostic** branch (not for merge) to pin the root cause of the long-standing `E2ELiveServices / macos-15-intel` flakiness.

## Background

The intel E2E job fails intermittently (~4/5 runs on the #1080 conda branch, and similarly on the uv migration branch #1082). It is **pre-existing and dependency-independent**. The failure mechanism: Electron quits gracefully mid-test (`app.on("before-quit")` → `exitPyProc`, `[electron] Exited with code 0`), which tears down the Flask backend and cascades every remaining test to failure (`Failed to fetch`, `dashboard.page` undefined, etc.). It is **not** the backend hot-reload watcher (ruled out with a targeted diagnostic) and **not** electron-vite reload (Electron does not restart after the exit).

## What this adds

Under the test suite only (`runByTestSuite`), logs:
- which signal (`SIGINT`/`SIGTERM`/`SIGHUP`) the Electron main process receives, if any (while preserving graceful shutdown);
- `render-process-gone` / `child-process-gone` events (renderer/GPU crashes);
- a stack trace when `before-quit` fires.

Once CI on the intel runner reveals the trigger, the real fix will replace these diagnostics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)